### PR TITLE
Remove app-name from platform api

### DIFF
--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -36,7 +36,7 @@ auto main(int /*unused*/, char* * /*unused*/) -> int {
   auto logger = log::Logger{log::makeConsolePrettySink(), log::makeFileJsonSink("sandbox.log")};
   LOG_I(&logger, "Sandbox startup");
 
-  auto platform = pal::Platform{&logger, "Tria sandbox"};
+  auto platform = pal::Platform{&logger};
   try {
     runApp(logger, platform);
   } catch (const std::exception& e) {

--- a/include/tria/pal/platform.hpp
+++ b/include/tria/pal/platform.hpp
@@ -2,8 +2,6 @@
 #include "tria/log/api.hpp"
 #include "tria/pal/window.hpp"
 #include <memory>
-#include <string>
-#include <string_view>
 
 namespace tria::pal {
 
@@ -17,17 +15,13 @@ class NativePlatform;
  */
 class Platform final {
 public:
-  Platform(log::Logger* logger, std::string appName);
+  Platform(log::Logger* logger);
   Platform(const Platform& rhs)     = delete;
   Platform(Platform&& rhs) noexcept = default;
   ~Platform();
 
   auto operator=(const Platform& rhs) -> Platform& = delete;
   auto operator=(Platform&& rhs) noexcept -> Platform& = default;
-
-  /* Get the name of this app.
-   */
-  [[nodiscard]] auto getAppName() const noexcept -> std::string_view;
 
   /* Handle any queued os events.
    * Should be called at a regular interval to be 'responsive' to the os.

--- a/src/tria/pal/native_platform.win32.cpp
+++ b/src/tria/pal/native_platform.win32.cpp
@@ -1,5 +1,6 @@
 #include "native_platform.win32.hpp"
 #include "tria/pal/err/platform_err.hpp"
+#include "tria/pal/utils.hpp"
 #include <array>
 
 namespace tria::pal {
@@ -56,6 +57,9 @@ auto WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept -> L
   // Default window behaviour if platform didn't consume the message.
   return DefWindowProc(hWnd, msg, wParam, lParam);
 }
+
+NativePlatform::NativePlatform(log::Logger* logger) :
+    m_logger{logger}, m_appName{getCurExecutableName()}, m_hInstance{nullptr}, m_nextWinId{1} {}
 
 NativePlatform::~NativePlatform() {
   while (!m_windows.empty()) {

--- a/src/tria/pal/native_platform.win32.hpp
+++ b/src/tria/pal/native_platform.win32.hpp
@@ -43,9 +43,7 @@ class NativePlatform final {
   friend auto WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept -> LRESULT;
 
 public:
-  NativePlatform(log::Logger* logger, std::string appName) :
-      m_logger{logger}, m_appName{std::move(appName)}, m_hInstance{nullptr}, m_nextWinId{1} {}
-
+  NativePlatform(log::Logger* logger);
   ~NativePlatform();
 
   [[nodiscard]] auto getAppName() const noexcept -> std::string_view { return m_appName; }

--- a/src/tria/pal/native_platform.xcb.hpp
+++ b/src/tria/pal/native_platform.xcb.hpp
@@ -21,12 +21,9 @@ struct WindowData {
 
 class NativePlatform final {
 public:
-  NativePlatform(log::Logger* logger, std::string appName) :
-      m_logger{logger}, m_appName{std::move(appName)}, m_xcbCon{nullptr}, m_xcbScreen{nullptr} {}
+  NativePlatform(log::Logger* logger) : m_logger{logger}, m_xcbCon{nullptr}, m_xcbScreen{nullptr} {}
 
   ~NativePlatform();
-
-  [[nodiscard]] auto getAppName() const noexcept -> std::string_view { return m_appName; }
 
   [[nodiscard]] auto getIsWinCloseRequested(WindowId id) const noexcept -> bool {
     auto* win = getWindow(id);
@@ -58,7 +55,6 @@ public:
 
 private:
   log::Logger* m_logger;
-  std::string m_appName;
   xcb_connection_t* m_xcbCon;
   xcb_screen_t* m_xcbScreen;
   xcb_atom_t m_xcbProtoMsgAtom;

--- a/src/tria/pal/platform.win32.cpp
+++ b/src/tria/pal/platform.win32.cpp
@@ -2,12 +2,9 @@
 
 namespace tria::pal {
 
-Platform::Platform(log::Logger* logger, std::string appName) :
-    m_native{std::make_unique<NativePlatform>(logger, std::move(appName))} {}
+Platform::Platform(log::Logger* logger) : m_native{std::make_unique<NativePlatform>(logger)} {}
 
 Platform::~Platform() = default;
-
-auto Platform::getAppName() const noexcept -> std::string_view { return m_native->getAppName(); }
 
 auto Platform::handleEvents() -> void { m_native->handleEvents(); }
 

--- a/src/tria/pal/platform.xcb.cpp
+++ b/src/tria/pal/platform.xcb.cpp
@@ -2,12 +2,9 @@
 
 namespace tria::pal {
 
-Platform::Platform(log::Logger* logger, std::string appName) :
-    m_native{std::make_unique<NativePlatform>(logger, std::move(appName))} {}
+Platform::Platform(log::Logger* logger) : m_native{std::make_unique<NativePlatform>(logger)} {}
 
 Platform::~Platform() = default;
-
-auto Platform::getAppName() const noexcept -> std::string_view { return m_native->getAppName(); }
 
 auto Platform::handleEvents() -> void { m_native->handleEvents(); }
 


### PR DESCRIPTION
Executable name is used instead