### PR TITLE
Support additional log param types

### DIFF
--- a/include/tria/log/message.hpp
+++ b/include/tria/log/message.hpp
@@ -39,7 +39,7 @@ public:
 
 private:
   const MetaData* m_meta;
-  std::chrono::system_clock::time_point m_time;
+  TimePoint m_time;
   std::vector<Param> m_params;
 };
 

--- a/include/tria/log/param.hpp
+++ b/include/tria/log/param.hpp
@@ -7,18 +7,40 @@
 namespace tria::log {
 
 /*
+ * Memory size.
+ * Wrapper around a size_t, that gives additional semantic information.
+ */
+class MemSize final {
+public:
+  explicit MemSize(size_t size) : m_size{size} {}
+
+  auto operator==(const MemSize& rhs) const noexcept -> bool { return m_size == rhs.m_size; }
+
+  [[nodiscard]] auto getSize() const noexcept { return m_size; }
+
+private:
+  size_t m_size;
+};
+
+/*
  * Runtime parameter to a log message.
  * Supported types:
  * - Integer types (stored in a signed/unsigned 64 bit integer).
  * - Floating point types (float and double, stored as a double).
  * - Bool
  * - String (stored as a copy).
+ * - MemSize (wrapper around size_t)
  *
  * Note: Keys should be literals or strings that have a longer lifetime then the logger.
  * Note: Because it can store std::string it should be moved whenever possible.
  */
 class Param final {
 public:
+  enum class WriteMode {
+    Pretty,
+    Json,
+  };
+
   Param() = delete;
 
   template <
@@ -41,6 +63,8 @@ public:
 
   Param(std::string_view key, std::string value) noexcept;
 
+  Param(std::string_view key, MemSize memSize) noexcept : m_key{key}, m_value{memSize} {}
+
   Param(const Param& rhs)     = default;
   Param(Param&& rhs) noexcept = default;
 
@@ -52,10 +76,10 @@ public:
 
   [[nodiscard]] constexpr auto getKey() const noexcept { return m_key; }
 
-  auto writeValue(std::string* tgtStr, bool quoteStrings) const noexcept -> void;
+  auto writeValue(std::string* tgtStr, WriteMode mode) const noexcept -> void;
 
 private:
-  using ValueType = std::variant<int64_t, uint64_t, double, bool, std::string>;
+  using ValueType = std::variant<int64_t, uint64_t, double, bool, std::string, MemSize>;
 
   std::string_view m_key;
   ValueType m_value;

--- a/include/tria/log/param.hpp
+++ b/include/tria/log/param.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <chrono>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -6,8 +7,11 @@
 
 namespace tria::log {
 
-/*
- * Memory size.
+/* Elapsed time.
+ */
+using Duration = std::chrono::duration<double>;
+
+/* Memory size.
  * Wrapper around a size_t, that gives additional semantic information.
  */
 class MemSize final {
@@ -22,13 +26,13 @@ private:
   size_t m_size;
 };
 
-/*
- * Runtime parameter to a log message.
+/* Runtime parameter to a log message.
  * Supported types:
  * - Integer types (stored in a signed/unsigned 64 bit integer).
  * - Floating point types (float and double, stored as a double).
  * - Bool
  * - String (stored as a copy).
+ * - Duration (std::chrono::duration<double>)
  * - MemSize (wrapper around size_t)
  *
  * Note: Keys should be literals or strings that have a longer lifetime then the logger.
@@ -63,7 +67,9 @@ public:
 
   Param(std::string_view key, std::string value) noexcept;
 
-  Param(std::string_view key, MemSize memSize) noexcept : m_key{key}, m_value{memSize} {}
+  Param(std::string_view key, Duration value) noexcept : m_key{key}, m_value{value} {}
+
+  Param(std::string_view key, MemSize value) noexcept : m_key{key}, m_value{value} {}
 
   Param(const Param& rhs)     = default;
   Param(Param&& rhs) noexcept = default;
@@ -79,7 +85,7 @@ public:
   auto writeValue(std::string* tgtStr, WriteMode mode) const noexcept -> void;
 
 private:
-  using ValueType = std::variant<int64_t, uint64_t, double, bool, std::string, MemSize>;
+  using ValueType = std::variant<int64_t, uint64_t, double, bool, std::string, Duration, MemSize>;
 
   std::string_view m_key;
   ValueType m_value;

--- a/include/tria/log/param.hpp
+++ b/include/tria/log/param.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <chrono>
+#include <ctime>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -10,6 +11,10 @@ namespace tria::log {
 /* Elapsed time.
  */
 using Duration = std::chrono::duration<double>;
+
+/* Point in time.
+ */
+using TimePoint = std::chrono::system_clock::time_point;
 
 /* Memory size.
  * Wrapper around a size_t, that gives additional semantic information.
@@ -30,10 +35,11 @@ private:
  * Supported types:
  * - Integer types (stored in a signed/unsigned 64 bit integer).
  * - Floating point types (float and double, stored as a double).
- * - Bool
+ * - Bool.
  * - String (stored as a copy).
- * - Duration (std::chrono::duration<double>)
- * - MemSize (wrapper around size_t)
+ * - Duration (std::chrono::duration<double>).
+ * - TimePoint (std::chrono::system_clock::time_point).
+ * - MemSize (wrapper around size_t).
  *
  * Note: Keys should be literals or strings that have a longer lifetime then the logger.
  * Note: Because it can store std::string it should be moved whenever possible.
@@ -69,6 +75,11 @@ public:
 
   Param(std::string_view key, Duration value) noexcept : m_key{key}, m_value{value} {}
 
+  Param(std::string_view key, TimePoint value) noexcept : m_key{key}, m_value{value} {}
+
+  Param(std::string_view key, std::time_t value) noexcept :
+      m_key{key}, m_value{std::chrono::system_clock::from_time_t(value)} {}
+
   Param(std::string_view key, MemSize value) noexcept : m_key{key}, m_value{value} {}
 
   Param(const Param& rhs)     = default;
@@ -85,7 +96,8 @@ public:
   auto writeValue(std::string* tgtStr, WriteMode mode) const noexcept -> void;
 
 private:
-  using ValueType = std::variant<int64_t, uint64_t, double, bool, std::string, Duration, MemSize>;
+  using ValueType =
+      std::variant<int64_t, uint64_t, double, bool, std::string, Duration, TimePoint, MemSize>;
 
   std::string_view m_key;
   ValueType m_value;

--- a/src/tria/log/internal/str_write.hpp
+++ b/src/tria/log/internal/str_write.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <array>
 #include <chrono>
+#include <cmath>
 #include <ctime>
 #include <string>
 #include <tria/log/level.hpp>
@@ -63,16 +64,16 @@ inline auto writeInt(std::string* str, IntType value) noexcept {
   str->append(std::string_view{buffer.data(), static_cast<std::string_view::size_type>(size)});
 }
 
-inline auto writeDouble(std::string* str, double value) noexcept {
+inline auto writeDouble(std::string* str, double value, const char* fmtStr = "%.10g") noexcept {
 
   // Check how many characters we need to represent the double.
-  const auto size = std::snprintf(nullptr, 0, "%.10g", value);
+  const auto size = std::snprintf(nullptr, 0, fmtStr, value);
 
   // Allocate a buffer on the stack with that size.
   auto buffer = static_cast<char*>(alloca(size + 1));
 
   // Write the characters in the stack buffer.
-  std::snprintf(buffer, size + 1, "%.10g", value);
+  std::snprintf(buffer, size + 1, fmtStr, value);
 
   // Wrap the buffer into a string_view and call the string_view overload.
   str->append(std::string_view{buffer, static_cast<std::string_view::size_type>(size)});
@@ -106,6 +107,22 @@ inline auto writeIsoTime(std::string* str, std::chrono::system_clock::time_point
   // Wrap the buffer into a string_view and call the string_view overload.
   str->append(
       std::string_view{buffer.data(), static_cast<std::string_view::size_type>(bufferSize - 1)});
+}
+
+inline auto writePrettyMemSize(std::string* str, const size_t size) noexcept {
+  constexpr static std::array<std::string_view, 6> units = {
+      " B", " KiB", " MiB", " GiB", " TiB", " PiB"};
+  auto unitIdx = 0U;
+  auto sizeD   = static_cast<double>(size);
+  for (; sizeD >= 1024.0 && unitIdx != units.size() - 1; ++unitIdx) {
+    sizeD /= 1024.0;
+  }
+  if (sizeD - std::floor(sizeD) < .1) {
+    writeInt(str, static_cast<uint64_t>(sizeD));
+  } else {
+    writeDouble(str, sizeD, "%.1f");
+  }
+  str->append(units[unitIdx]);
 }
 
 } // namespace tria::log::internal

--- a/src/tria/log/internal/str_write.hpp
+++ b/src/tria/log/internal/str_write.hpp
@@ -109,9 +109,27 @@ inline auto writeIsoTime(std::string* str, std::chrono::system_clock::time_point
       std::string_view{buffer.data(), static_cast<std::string_view::size_type>(bufferSize - 1)});
 }
 
+inline auto writePrettyDuration(std::string* str, std::chrono::duration<double> dur) noexcept {
+  constexpr static std::array<std::string_view, 4> units = {" sec", " ms", " us", " ns"};
+
+  auto unitIdx = 0U;
+  auto t       = dur.count();
+  for (; t < 1.0 && unitIdx != units.size() - 1; ++unitIdx) {
+    t *= 1000.0;
+  }
+  const auto rounded = std::round(t);
+  if (std::abs(t - rounded) < .05) {
+    writeInt(str, static_cast<uint64_t>(rounded));
+  } else {
+    writeDouble(str, t, "%.1f");
+  }
+  str->append(units[unitIdx]);
+}
+
 inline auto writePrettyMemSize(std::string* str, const size_t size) noexcept {
   constexpr static std::array<std::string_view, 6> units = {
       " B", " KiB", " MiB", " GiB", " TiB", " PiB"};
+
   auto unitIdx = 0U;
   auto sizeD   = static_cast<double>(size);
   for (; sizeD >= 1024.0 && unitIdx != units.size() - 1; ++unitIdx) {

--- a/src/tria/log/json_sink.cpp
+++ b/src/tria/log/json_sink.cpp
@@ -56,7 +56,7 @@ public:
         m_buffer.append(itr->getKey());
         m_buffer.append("\": ");
 
-        itr->writeValue(&m_buffer, true);
+        itr->writeValue(&m_buffer, Param::WriteMode::Json);
 
         auto isLast = itr == msg.end() - 1;
         if (!isLast) {

--- a/src/tria/log/param.cpp
+++ b/src/tria/log/param.cpp
@@ -84,6 +84,14 @@ auto Param::writeValue(std::string* tgtStr, WriteMode mode) const noexcept -> vo
             internal::writePrettyDuration(tgtStr, arg);
             break;
           }
+        } else if constexpr (std::is_same_v<T, TimePoint>) {
+          if (mode == WriteMode::Json) {
+            tgtStr->append("\"");
+          }
+          internal::writeIsoTime(tgtStr, arg);
+          if (mode == WriteMode::Json) {
+            tgtStr->append("\"");
+          }
         }
         // NOLINTNEXTLINE(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, MemSize>)

--- a/src/tria/log/param.cpp
+++ b/src/tria/log/param.cpp
@@ -71,7 +71,22 @@ auto Param::writeValue(std::string* tgtStr, WriteMode mode) const noexcept -> vo
           if (mode == WriteMode::Json) {
             tgtStr->append("\"");
           }
-        } else if constexpr (std::is_same_v<T, MemSize>)
+        }
+        // NOLINTNEXTLINE(bugprone-branch-clone)
+        else if constexpr (std::is_same_v<T, Duration>) {
+          switch (mode) {
+          case WriteMode::Json: {
+            // In json write the elapsed nanoseconds.
+            auto nanoSec = std::chrono::duration_cast<std::chrono::nanoseconds>(arg).count();
+            internal::writeInt(tgtStr, nanoSec);
+          } break;
+          case WriteMode::Pretty:
+            internal::writePrettyDuration(tgtStr, arg);
+            break;
+          }
+        }
+        // NOLINTNEXTLINE(bugprone-branch-clone)
+        else if constexpr (std::is_same_v<T, MemSize>)
           switch (mode) {
           case WriteMode::Json:
             // In json just write the size in bytes.

--- a/src/tria/log/pretty_sink.cpp
+++ b/src/tria/log/pretty_sink.cpp
@@ -95,7 +95,7 @@ public:
 
         appendStyle(ansiBold());
 
-        param.writeValue(&m_buffer, false);
+        param.writeValue(&m_buffer, Param::WriteMode::Pretty);
         m_buffer.append("\n");
 
         appendStyle(ansiReset());

--- a/tests/tria/log/param_test.cpp
+++ b/tests/tria/log/param_test.cpp
@@ -6,21 +6,60 @@ namespace tria::log::tests {
 
 namespace {
 
-auto paramValueToString(const Param& param) {
+auto toStringPretty(const Param& param) {
   auto str = std::string{};
-  param.writeValue(&str, true);
+  param.writeValue(&str, Param::WriteMode::Pretty);
+  return str;
+}
+
+auto toStringJson(const Param& param) {
+  auto str = std::string{};
+  param.writeValue(&str, Param::WriteMode::Json);
   return str;
 }
 
 } // namespace
 
 TEST_CASE("Log write param", "[log]") {
-  CHECK(paramValueToString({"key", 42}) == "42");
-  CHECK(paramValueToString({"key", 100'000'000}) == "100000000");
-  CHECK_THAT(paramValueToString({"key", 1.337F}), Catch::StartsWith("1.337"));
-  CHECK_THAT(paramValueToString({"key", 1.333337}), Catch::StartsWith("1.333337"));
-  CHECK(paramValueToString({"key", "Hello World"}) == "\"Hello World\"");
-  CHECK(paramValueToString({"key", std::string{"Hello World"}}) == "\"Hello World\"");
+
+  SECTION("Pretty") {
+    CHECK(toStringPretty({"key", 42}) == "42");
+    CHECK(toStringPretty({"key", 100'000'000}) == "100000000");
+
+    CHECK_THAT(toStringPretty({"key", 1.337F}), Catch::StartsWith("1.337"));
+    CHECK_THAT(toStringPretty({"key", 1.333337}), Catch::StartsWith("1.333337"));
+
+    CHECK(toStringPretty({"key", "Hello World"}) == "Hello World");
+    CHECK(toStringPretty({"key", std::string{"Hello World"}}) == "Hello World");
+    CHECK(toStringPretty({"key", std::string{"Hello\tWorld\n"}}) == "Hello\\tWorld\\n");
+
+    CHECK(toStringPretty({"key", MemSize{0}}) == "0 B");
+    CHECK(toStringPretty({"key", MemSize{1024}}) == "1 KiB");
+    CHECK(toStringPretty({"key", MemSize{1024UL * 1024}}) == "1 MiB");
+    CHECK(toStringPretty({"key", MemSize{1024UL * 1024 * 1024}}) == "1 GiB");
+    CHECK(toStringPretty({"key", MemSize{1024UL * 1024 * 1024 * 1024}}) == "1 TiB");
+    CHECK(toStringPretty({"key", MemSize{1024UL * 1024 * 1024 * 1024 * 1024}}) == "1 PiB");
+    CHECK(
+        toStringPretty({"key", MemSize{1024UL * 1024 * 1024 * 1024 * 1024 * 1024}}) == "1024 PiB");
+
+    CHECK(toStringPretty({"key", MemSize{42}}) == "42 B");
+    CHECK(toStringPretty({"key", MemSize{4242}}) == "4.1 KiB");
+    CHECK(toStringPretty({"key", MemSize{424242}}) == "414.3 KiB");
+  }
+
+  SECTION("Json") {
+    CHECK(toStringJson({"key", 42}) == "42");
+    CHECK(toStringJson({"key", 100'000'000}) == "100000000");
+
+    CHECK_THAT(toStringJson({"key", 1.337F}), Catch::StartsWith("1.337"));
+    CHECK_THAT(toStringJson({"key", 1.333337}), Catch::StartsWith("1.333337"));
+
+    CHECK(toStringJson({"key", "Hello World"}) == "\"Hello World\"");
+    CHECK(toStringJson({"key", std::string{"Hello World"}}) == "\"Hello World\"");
+    CHECK(toStringJson({"key", std::string{"Hello\tWorld\n"}}) == "\"Hello\\tWorld\\n\"");
+
+    CHECK(toStringJson({"key", MemSize{1024UL * 1024}}) == "1048576");
+  }
 }
 
 } // namespace tria::log::tests

--- a/tests/tria/log/param_test.cpp
+++ b/tests/tria/log/param_test.cpp
@@ -2,6 +2,8 @@
 #include "tria/log/param.hpp"
 #include <string>
 
+using namespace std::literals;
+
 namespace tria::log::tests {
 
 namespace {
@@ -33,6 +35,17 @@ TEST_CASE("Log write param", "[log]") {
     CHECK(toStringPretty({"key", std::string{"Hello World"}}) == "Hello World");
     CHECK(toStringPretty({"key", std::string{"Hello\tWorld\n"}}) == "Hello\\tWorld\\n");
 
+    CHECK(toStringPretty({"key", 137ns}) == "137 ns");
+    CHECK(toStringPretty({"key", 1337ns}) == "1.3 us");
+    CHECK(toStringPretty({"key", 42ns}) == "42 ns");
+    CHECK(toStringPretty({"key", 42us}) == "42 us");
+    CHECK(toStringPretty({"key", 42ms}) == "42 ms");
+    CHECK(toStringPretty({"key", 42s}) == "42 sec");
+    CHECK(toStringPretty({"key", 420s}) == "420 sec");
+    CHECK(toStringPretty({"key", 42us + 51ns}) == "42.1 us");
+    CHECK(toStringPretty({"key", 42us + 49ns}) == "42 us");
+    CHECK(toStringPretty({"key", 1s + 900ms}) == "1.9 sec");
+
     CHECK(toStringPretty({"key", MemSize{0}}) == "0 B");
     CHECK(toStringPretty({"key", MemSize{1024}}) == "1 KiB");
     CHECK(toStringPretty({"key", MemSize{1024UL * 1024}}) == "1 MiB");
@@ -57,6 +70,12 @@ TEST_CASE("Log write param", "[log]") {
     CHECK(toStringJson({"key", "Hello World"}) == "\"Hello World\"");
     CHECK(toStringJson({"key", std::string{"Hello World"}}) == "\"Hello World\"");
     CHECK(toStringJson({"key", std::string{"Hello\tWorld\n"}}) == "\"Hello\\tWorld\\n\"");
+
+    CHECK(toStringJson({"key", 42ns}) == "42");
+    CHECK(toStringJson({"key", 42us}) == "42000");
+    CHECK(toStringJson({"key", 42ms}) == "42000000");
+    CHECK(toStringJson({"key", 42s}) == "42000000000");
+    CHECK(toStringJson({"key", 42s + 42ms + 42us + 42ns}) == "42042042042");
 
     CHECK(toStringJson({"key", MemSize{1024UL * 1024}}) == "1048576");
   }


### PR DESCRIPTION
Adds support for 3 new types of log parameters:
* Time duration (`std::chrono::duration<double>`)
* Timestamp (`std::chrono::system_clock::time_point`, or `std::time_t`)
* Memory size (`size_t`)

Example usage:
```c++
LOG_I(logger, "Hello World",
      {"size", log::MemSize(1333333337)},
      {"dur", 42ms + 137us},
      {"time", std::chrono::system_clock::now()});
```
console output:
![image](https://user-images.githubusercontent.com/14230060/87313430-88a47900-c52a-11ea-8b79-879ec257db63.png)