### PR TITLE
Basic asset library

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,5 +12,15 @@
       "terminal": "integrated",
       "stopOnEntry": false
     },
+    {
+      "name": "tria_tests",
+      "preLaunchTask": "build",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/tria_tests",
+      "cwd": "${workspaceFolder}",
+      "terminal": "integrated",
+      "stopOnEntry": false
+    }
   ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ else()
   if(${TRIA_PLATFORM} STREQUAL "win32")
     set(CXX_FLAGS_SHARED "${CXX_FLAGS_SHARED} ${CXX_FLAGS_WIN32}")
   endif()
-  set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -fno-omit-frame-pointer ${CXX_FLAGS_SHARED}")
+  set(CMAKE_CXX_FLAGS_DEBUG "-Og -g -fno-omit-frame-pointer ${CXX_FLAGS_SHARED}")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG ${CXX_FLAGS_SHARED}")
 endif()
 
@@ -82,9 +82,6 @@ if(LINTING)
     set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BIN})
   endif()
 endif()
-
-# Write a 'VERSION' file to the bin dir with the cmake project version.
-file(WRITE ${EXECUTABLE_OUTPUT_PATH}/VERSION ${CMAKE_PROJECT_VERSION})
 
 # Replace config variables in the config header.
 configure_file("include/tria/config.hpp.in" "${PROJECT_SOURCE_DIR}/include/tria/config.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
   message(STATUS "Setting unix compiler flags")
   set(CXX_FLAGS_SHARED "-std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing")
   if(${TRIA_PLATFORM} STREQUAL "win32")
-    set(CXX_FLAGS_SHARED "${CXX_FLAGS_SHARED} ${CXX_FLAGS_WIN32}")
+    set(CXX_FLAGS_SHARED "${CXX_FLAGS_SHARED} ${CXX_FLAGS_WIN32} -Wno-deprecated-declarations")
   endif()
   set(CMAKE_CXX_FLAGS_DEBUG "-Og -g -fno-omit-frame-pointer ${CXX_FLAGS_SHARED}")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG ${CXX_FLAGS_SHARED}")
@@ -74,14 +74,18 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # reason is that MinGW does not respect that file.
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
 
-if(LINTING)
-  # Use the clang-tidy linter if installed.
-  find_program(CLANG_TIDY_BIN NAMES "clang-tidy" "clang-tidy-9")
-  if(CLANG_TIDY_BIN)
-    message(STATUS "Enabling clang-tidy linter")
-    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BIN})
+# Define a function that can be used to enable linting tools.
+# Reason why not to just enable it here is that we don't want to run it on external code.
+function(enable_linting)
+  if(LINTING)
+    # Use the clang-tidy linter if installed.
+    find_program(CLANG_TIDY_BIN NAMES "clang-tidy" "clang-tidy-9")
+    if(CLANG_TIDY_BIN)
+      message(STATUS "Enabling clang-tidy linter")
+      set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BIN})
+    endif()
   endif()
-endif()
+endfunction()
 
 # Replace config variables in the config header.
 configure_file("include/tria/config.hpp.in" "${PROJECT_SOURCE_DIR}/include/tria/config.hpp")

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Enable linting, add external code above this line.
+enable_linting()
+
 # Sandbox.
 message(STATUS "Configuring sandbox executable")
 add_executable(sandbox

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -3,6 +3,7 @@ message(STATUS "Configuring sandbox executable")
 add_executable(sandbox
   sandbox/main.cpp)
 target_compile_features(sandbox PUBLIC cxx_std_17)
+target_link_libraries(sandbox PRIVATE tria_asset)
 target_link_libraries(sandbox PRIVATE tria_pal)
 target_link_libraries(sandbox PRIVATE tria_log)
 target_link_libraries(sandbox PRIVATE tria_gfx)

--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -59,7 +59,7 @@ auto runApp(log::Logger& logger, pal::Platform& platform) -> int {
 
 auto main(int /*unused*/, char* * /*unused*/) -> int {
 
-  pal::setThreadName("main_thread");
+  pal::setThreadName("tria_main_thread");
   pal::setupInterruptHandler();
 
   auto logger = log::Logger{log::makeConsolePrettySink(), log::makeFileJsonSink("sandbox.log")};

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -26,9 +26,30 @@ function(configure_shaders)
   endforeach()
 
   # Add a custom target that depends on all shaders files.
-  # That way executables can easiliy depend on the shaders.
   add_custom_target(tria_shaders DEPENDS ${shaderArtifacts})
 endfunction(configure_shaders)
+
+function(configure_plainfiles)
+  set(srcDir ${CMAKE_CURRENT_SOURCE_DIR})
+  set(dstDir ${EXECUTABLE_OUTPUT_PATH}/data)
+
+  # Create output directory.
+  file(MAKE_DIRECTORY ${dstDir})
+
+  # Copy each file to the output directory.
+  foreach(file IN LISTS ARGN)
+    set(fileSrc ${srcDir}/${file})
+    set(fileDst ${dstDir}/${file})
+
+    configure_file(${fileSrc} ${fileDst} COPYONLY)
+
+    # Keep a list of all ouput files.
+    list(APPEND plainArtifacts ${fileDst})
+  endforeach()
+
+  # Add a custom target that depends on all plain files.
+  add_custom_target(tria_plainfiles DEPENDS ${plainArtifacts})
+endfunction(configure_plainfiles)
 
 # Shaders.
 message(STATUS "Configuring shaders")
@@ -36,6 +57,11 @@ configure_shaders(
   triangle.vert
   triangle.frag)
 
+# Plain files
+message(STATUS "Configuring plain files")
+configure_plainfiles(
+  triangle.gfx)
+
 # Wrapper dependency that depends on all types of data.
 add_custom_target(tria_data)
-add_dependencies(tria_data tria_shaders)
+add_dependencies(tria_data tria_shaders tria_plainfiles)

--- a/data/triangle.gfx
+++ b/data/triangle.gfx
@@ -1,0 +1,4 @@
+{
+  "vertShader": "shaders/triangle.vert.spv",
+  "fragShader": "shaders/triangle.frag.spv"
+}

--- a/include/tria/asset/asset.hpp
+++ b/include/tria/asset/asset.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include "tria/asset/asset_kind.hpp"
+#include "tria/asset/err/asset_type_err.hpp"
+#include <string>
+
+namespace tria::asset {
+
+using AssetId = std::string;
+
+/*
+ * Abstract base class for asset implementations.
+ */
+class Asset {
+public:
+  Asset()                     = delete;
+  Asset(const Asset& rhs)     = delete;
+  Asset(Asset&& rhs) noexcept = delete;
+  virtual ~Asset()            = default;
+
+  auto operator=(const Asset& rhs) -> Asset& = delete;
+  auto operator=(Asset&& rhs) noexcept -> Asset& = delete;
+
+  [[nodiscard]] auto getId() const noexcept -> const AssetId& { return m_id; }
+  [[nodiscard]] auto getKind() const noexcept { return m_kind; }
+
+  template <typename AssetType>
+  [[nodiscard]] auto downcast() const -> const AssetType* {
+    if (getKind() != AssetType::getKind()) {
+      throw err::AssetTypeErr{"Invalid downcast"};
+    }
+    return static_cast<const AssetType*>(this);
+  }
+
+protected:
+  Asset(AssetId id, AssetKind kind) noexcept : m_id{std::move(id)}, m_kind{kind} {}
+
+private:
+  AssetId m_id;
+  AssetKind m_kind;
+};
+
+} // namespace tria::asset

--- a/include/tria/asset/asset_kind.hpp
+++ b/include/tria/asset/asset_kind.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+#include <string_view>
+
+namespace tria::asset {
+
+enum class AssetKind : uint8_t {
+  Raw    = 1,
+  Shader = 2,
+};
+
+[[nodiscard]] constexpr auto getName(AssetKind kind) noexcept -> std::string_view {
+  switch (kind) {
+  case AssetKind::Raw:
+    return "raw";
+  case AssetKind::Shader:
+    return "shader";
+  }
+  return "unkown";
+}
+
+} // namespace tria::asset

--- a/include/tria/asset/asset_kind.hpp
+++ b/include/tria/asset/asset_kind.hpp
@@ -5,8 +5,9 @@
 namespace tria::asset {
 
 enum class AssetKind : uint8_t {
-  Raw    = 1,
-  Shader = 2,
+  Raw     = 1,
+  Shader  = 2,
+  Graphic = 3,
 };
 
 [[nodiscard]] constexpr auto getName(AssetKind kind) noexcept -> std::string_view {
@@ -15,6 +16,8 @@ enum class AssetKind : uint8_t {
     return "raw";
   case AssetKind::Shader:
     return "shader";
+  case AssetKind::Graphic:
+    return "graphic";
   }
   return "unkown";
 }

--- a/include/tria/asset/database.hpp
+++ b/include/tria/asset/database.hpp
@@ -27,6 +27,7 @@ public:
   auto operator=(Database&& rhs) noexcept -> Database& = default;
 
   /* Load an asset with a given id.
+   * Throws if asset loading fails.
    * Is thread-safe.
    */
   [[nodiscard]] auto get(const AssetId& id) -> const Asset*;

--- a/include/tria/asset/database.hpp
+++ b/include/tria/asset/database.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "tria/asset/asset.hpp"
+#include "tria/fs.hpp"
+#include "tria/log/api.hpp"
+
+namespace tria::asset {
+
+class DatabaseImpl;
+
+/*
+ * Database for loading assets from.
+ * Assets are loaded lazily but cached for future requests.
+ * Currently assets cannot be unloaded, in the future some ref-counting smart-pointer-like handle
+ * should be returned to track asset usage.
+ *
+ * Api is threadsafe.
+ */
+class Database final {
+public:
+  Database() = delete;
+  Database(log::Logger* logger, fs::path rootPath);
+  Database(const Database& rhs)     = delete;
+  Database(Database&& rhs) noexcept = default;
+  ~Database();
+
+  auto operator=(const Database& rhs) -> Database& = delete;
+  auto operator=(Database&& rhs) noexcept -> Database& = default;
+
+  /* Load an asset with a given id.
+   * Is thread-safe.
+   */
+  [[nodiscard]] auto get(const AssetId& id) -> const Asset*;
+
+private:
+  std::unique_ptr<DatabaseImpl> m_impl;
+};
+
+} // namespace tria::asset

--- a/include/tria/asset/err/asset_load_err.hpp
+++ b/include/tria/asset/err/asset_load_err.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include "tria/fs.hpp"
+#include <exception>
+#include <string>
+#include <string_view>
+
+namespace tria::asset::err {
+
+/*
+ * Exception that is thrown when there is an error loading an asset.
+ */
+class AssetLoadErr final : public std::exception {
+public:
+  AssetLoadErr() = delete;
+  AssetLoadErr(const fs::path& path, std::string_view msg) :
+      m_path{path},
+      m_innerMsg{msg},
+      m_msg{std::string{"Asset load error: "} + std::string{msg} + ": " + m_path.string()} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char* override { return m_msg.c_str(); }
+
+  [[nodiscard]] auto getInnerMsg() const noexcept -> const std::string_view { return m_innerMsg; }
+
+  [[nodiscard]] auto getPath() const noexcept -> const fs::path& { return m_path; }
+
+private:
+  fs::path m_path;
+  std::string m_innerMsg;
+  std::string m_msg;
+};
+
+} // namespace tria::asset::err

--- a/include/tria/asset/err/asset_type_err.hpp
+++ b/include/tria/asset/err/asset_type_err.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <exception>
+#include <string>
+#include <string_view>
+
+namespace tria::asset::err {
+
+/*
+ * Exception that is thrown when an unexpected asset type is encountered.
+ */
+class AssetTypeErr final : public std::exception {
+public:
+  AssetTypeErr() = delete;
+  AssetTypeErr(std::string_view msg) : m_msg{std::string{"Asset type err: "} + std::string{msg}} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char* override { return m_msg.c_str(); }
+
+private:
+  std::string m_msg;
+};
+
+} // namespace tria::asset::err

--- a/include/tria/asset/graphic.hpp
+++ b/include/tria/asset/graphic.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include "tria/asset/shader.hpp"
+
+namespace tria::asset {
+
+/*
+ * Asset containing data needed for a drawing graphic.
+ */
+class Graphic final : public Asset {
+public:
+  Graphic(AssetId id, const Shader* vertShader, const Shader* fragShader) :
+      Asset{std::move(id), getKind()}, m_vertShader{vertShader}, m_fragShader{fragShader} {}
+  Graphic(const Graphic& rhs) = delete;
+  Graphic(Graphic&& rhs)      = delete;
+  ~Graphic() noexcept         = default;
+
+  auto operator=(const Graphic& rhs) -> Graphic& = delete;
+  auto operator=(Graphic&& rhs) -> Graphic& = delete;
+
+  [[nodiscard]] constexpr static auto getKind() -> AssetKind { return AssetKind::Graphic; }
+
+  [[nodiscard]] auto getVertShader() const noexcept { return m_vertShader; }
+  [[nodiscard]] auto getFragShader() const noexcept { return m_fragShader; }
+
+private:
+  const Shader* m_vertShader;
+  const Shader* m_fragShader;
+};
+
+} // namespace tria::asset

--- a/include/tria/asset/raw_asset.hpp
+++ b/include/tria/asset/raw_asset.hpp
@@ -1,0 +1,29 @@
+#include "tria/asset/asset.hpp"
+#include <vector>
+
+namespace tria::asset {
+
+/*
+ * Assets where we have no special loader for, just contains the raw bytes.
+ */
+class RawAsset final : public Asset {
+public:
+  RawAsset(AssetId id, std::vector<char> data) :
+      Asset{std::move(id), getKind()}, m_data{std::move(data)} {}
+  RawAsset(const RawAsset& rhs) = delete;
+  RawAsset(RawAsset&& rhs)      = delete;
+  ~RawAsset() noexcept          = default;
+
+  auto operator=(const RawAsset& rhs) -> RawAsset& = delete;
+  auto operator=(RawAsset&& rhs) -> RawAsset& = delete;
+
+  [[nodiscard]] constexpr static auto getKind() -> AssetKind { return AssetKind::Raw; }
+
+  [[nodiscard]] auto getSize() const noexcept { return m_data.size(); }
+  [[nodiscard]] auto getData() const noexcept -> const char* { return m_data.data(); }
+
+private:
+  std::vector<char> m_data;
+};
+
+} // namespace tria::asset

--- a/include/tria/asset/raw_asset.hpp
+++ b/include/tria/asset/raw_asset.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "tria/asset/asset.hpp"
 #include <vector>
 

--- a/include/tria/asset/shader.hpp
+++ b/include/tria/asset/shader.hpp
@@ -1,0 +1,38 @@
+#include "tria/asset/asset.hpp"
+#include <vector>
+
+namespace tria::asset {
+
+enum class ShaderKind : uint8_t {
+  SpvVertex   = 1,
+  SpvFragment = 2,
+};
+
+/*
+ * Asset containing shader code.
+ * Note: only contains the raw shader code, this asset is not reposible for uploading to the gpu.
+ */
+class Shader final : public Asset {
+public:
+  Shader(AssetId id, ShaderKind shaderKind, std::vector<char> data) :
+      Asset{std::move(id), getKind()}, m_shaderKind{shaderKind}, m_data{std::move(data)} {}
+  Shader(const Shader& rhs) = delete;
+  Shader(Shader&& rhs)      = delete;
+  ~Shader() noexcept        = default;
+
+  auto operator=(const Shader& rhs) -> Shader& = delete;
+  auto operator=(Shader&& rhs) -> Shader& = delete;
+
+  [[nodiscard]] constexpr static auto getKind() -> AssetKind { return AssetKind::Shader; }
+
+  [[nodiscard]] auto getShaderKind() const noexcept { return m_shaderKind; }
+
+  [[nodiscard]] auto getSize() const noexcept { return m_data.size(); }
+  [[nodiscard]] auto getData() const noexcept -> const char* { return m_data.data(); }
+
+private:
+  ShaderKind m_shaderKind;
+  std::vector<char> m_data;
+};
+
+} // namespace tria::asset

--- a/include/tria/asset/shader.hpp
+++ b/include/tria/asset/shader.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "tria/asset/asset.hpp"
 #include <vector>
 

--- a/include/tria/gfx/err/driver_err.hpp
+++ b/include/tria/gfx/err/driver_err.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <exception>
 #include <string>
+#include <string_view>
 
 namespace tria::gfx::err {
 
@@ -10,7 +11,7 @@ namespace tria::gfx::err {
 class DriverErr final : public std::exception {
 public:
   DriverErr() = delete;
-  DriverErr(const std::string& msg) : m_msg{std::string{"Gfx driver error: "} + msg} {}
+  DriverErr(std::string_view msg) : m_msg{std::string{"Gfx driver error: "} + std::string{msg}} {}
 
   [[nodiscard]] auto what() const noexcept -> const char* override { return m_msg.c_str(); }
 

--- a/include/tria/gfx/err/sync_err.hpp
+++ b/include/tria/gfx/err/sync_err.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <exception>
 #include <string>
+#include <string_view>
 
 namespace tria::gfx::err {
 
@@ -10,7 +11,7 @@ namespace tria::gfx::err {
 class SyncErr final : public std::exception {
 public:
   SyncErr() = delete;
-  SyncErr(const std::string& msg) : m_msg{std::string{"Sync error: "} + msg} {}
+  SyncErr(std::string_view msg) : m_msg{std::string{"Sync error: "} + std::string{msg}} {}
 
   [[nodiscard]] auto what() const noexcept -> const char* override { return m_msg.c_str(); }
 

--- a/include/tria/log/level.hpp
+++ b/include/tria/log/level.hpp
@@ -49,9 +49,8 @@ enum class Level : uint8_t {
     return "wrn";
   case Level::Error:
     return "err";
-  default:
-    return "unk";
   }
+  return "unk";
 }
 
 } // namespace tria::log

--- a/include/tria/log/param.hpp
+++ b/include/tria/log/param.hpp
@@ -70,6 +70,8 @@ public:
 
   Param(std::string_view key, const char* value) noexcept : Param(key, std::string(value)) {}
 
+  Param(std::string_view key, std::string_view value) noexcept : Param(key, std::string(value)) {}
+
   Param(std::string_view key, std::string value) noexcept;
 
   Param(std::string_view key, Duration value) noexcept : m_key{key}, m_value{value} {}

--- a/include/tria/pal/err/platform_err.hpp
+++ b/include/tria/pal/err/platform_err.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <exception>
 #include <string>
+#include <string_view>
 
 namespace tria::pal::err {
 
@@ -10,8 +11,9 @@ namespace tria::pal::err {
 class PlatformErr final : public std::exception {
 public:
   PlatformErr() = delete;
-  PlatformErr(unsigned long platformCode, const std::string& platformMsg) :
-      m_platformCode{platformCode}, m_platformMsg{std::string{"Platform error: "} + platformMsg} {}
+  PlatformErr(unsigned long platformCode, std::string_view platformMsg) :
+      m_platformCode{platformCode},
+      m_platformMsg{std::string{"Platform error: "} + std::string{platformMsg}} {}
 
   [[nodiscard]] auto what() const noexcept -> const char* override { return m_platformMsg.c_str(); }
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -82,8 +82,8 @@ function BuildProjMSBuild([int] $threads, [string] $dir) {
 
   # Msbuild creates extra empty directores in the output directory, we remove those as it
   # just clutters up the output.
-  Remove-Item "$dir\..\bin\Debug" -Force -ErrorAction Ignore
-  Remove-Item "$dir\..\bin\Release" -Force -ErrorAction Ignore
+  Remove-Item "$dir\..\bin\Debug" -Recurse -Force -Confirm:$false -ErrorAction Ignore
+  Remove-Item "$dir\..\bin\Release" -Recurse -Force -Confirm:$false -ErrorAction Ignore
 
   if ($msbuildResult -ne 0) {
     Fail "Build failed"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,22 @@
+include(FetchContent)
+
+# External: 'simdjson' json parsing library.
+message(STATUS "Fetching dependency: simdjson")
+FetchContent_Declare(
+  simdjson
+  GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+  GIT_TAG v0.4.6
+  GIT_SHALLOW TRUE)
+set(SIMDJSON_JUST_LIBRARY ON CACHE INTERNAL "")
+set(SIMDJSON_BUILD_STATIC ON CACHE INTERNAL "")
+set(SIMDJSON_COMPETITION OFF CACHE INTERNAL "")
+FetchContent_MakeAvailable(simdjson)
+
 # Asset (asset loading library).
 message(STATUS "Configuring asset library")
 add_library(tria_asset STATIC
+  tria/asset/internal/graphic_loader.cpp
+  tria/asset/internal/json.cpp
   tria/asset/internal/loader.cpp
   tria/asset/internal/raw_asset_loader.cpp
   tria/asset/internal/shader_loader.cpp
@@ -8,6 +24,7 @@ add_library(tria_asset STATIC
   tria/asset/database_impl.cpp)
 target_compile_features(tria_asset PRIVATE cxx_std_17)
 target_include_directories(tria_asset PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(tria_asset PRIVATE simdjson)
 target_link_libraries(tria_asset PRIVATE tria_log)
 target_link_libraries(tria_asset PRIVATE Threads::Threads)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Asset (asset loading library).
+message(STATUS "Configuring asset library")
+add_library(tria_asset STATIC
+  tria/asset/internal/loader.cpp
+  tria/asset/internal/raw_asset_loader.cpp
+  tria/asset/internal/shader_loader.cpp
+  tria/asset/database.cpp
+  tria/asset/database_impl.cpp)
+target_compile_features(tria_asset PRIVATE cxx_std_17)
+target_include_directories(tria_asset PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(tria_asset PRIVATE tria_log)
+target_link_libraries(tria_asset PRIVATE Threads::Threads)
+
 # Gfx (graphics library).
 message(STATUS "Configuring gfx vulkan library")
 add_library(tria_gfx STATIC
@@ -25,7 +38,6 @@ endif()
 
 target_compile_features(tria_gfx PRIVATE cxx_std_17)
 target_include_directories(tria_gfx PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(tria_gfx PRIVATE log)
 target_link_libraries(tria_gfx PRIVATE tria_pal)
 target_link_libraries(tria_gfx PRIVATE tria_log)
 
@@ -38,7 +50,6 @@ add_library(tria_log STATIC
   tria/log/pretty_sink.cpp)
 target_compile_features(tria_log PRIVATE cxx_std_17)
 target_include_directories(tria_log PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(tria_log PRIVATE log)
 target_link_libraries(tria_log PRIVATE Threads::Threads)
 target_link_libraries(tria_log PRIVATE tria_pal)
 
@@ -69,7 +80,6 @@ elseif(${TRIA_PLATFORM} STREQUAL "win32")
 endif()
 target_compile_features(tria_pal PRIVATE cxx_std_17)
 target_include_directories(tria_pal PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(tria_pal PRIVATE pal)
-target_include_directories(tria_pal PRIVATE tria_log)
+target_link_libraries(tria_pal PRIVATE tria_log)
 target_link_libraries(tria_pal PRIVATE Threads::Threads)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,9 @@ set(SIMDJSON_BUILD_STATIC ON CACHE INTERNAL "")
 set(SIMDJSON_COMPETITION OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(simdjson)
 
+# Enable linting, add external code above this line.
+enable_linting()
+
 # Asset (asset loading library).
 message(STATUS "Configuring asset library")
 add_library(tria_asset STATIC

--- a/src/tria/asset/database.cpp
+++ b/src/tria/asset/database.cpp
@@ -1,0 +1,13 @@
+#include "tria/asset/database.hpp"
+#include "database_impl.hpp"
+
+namespace tria::asset {
+
+Database::Database(log::Logger* logger, fs::path rootPath) :
+    m_impl{std::make_unique<DatabaseImpl>(logger, std::move(rootPath))} {}
+
+Database::~Database() = default;
+
+[[nodiscard]] auto Database::get(const AssetId& id) -> const Asset* { return m_impl->get(id); }
+
+} // namespace tria::asset

--- a/src/tria/asset/database_impl.cpp
+++ b/src/tria/asset/database_impl.cpp
@@ -1,0 +1,87 @@
+#include "database_impl.hpp"
+#include "internal/loader.hpp"
+#include "tria/asset/asset.hpp"
+#include "tria/asset/err/asset_load_err.hpp"
+#include <cassert>
+#include <chrono>
+#include <fstream>
+
+namespace tria::asset {
+
+using RawData = std::vector<char>;
+using Clock   = std::chrono::high_resolution_clock;
+
+namespace {
+
+auto loadRaw(const fs::path& path) -> RawData {
+  auto file = std::ifstream{path.string(), std::ios::ate | std::ios::binary};
+  if (!file.is_open()) {
+    throw err::AssetLoadErr(path, "Failed to open file");
+  }
+  const auto fileSize = static_cast<size_t>(file.tellg());
+  auto buffer         = std::vector<char>(fileSize);
+  file.seekg(0);
+  file.read(buffer.data(), fileSize);
+  file.close();
+  return buffer;
+}
+
+} // namespace
+
+auto DatabaseImpl::get(const AssetId& id) -> const Asset* {
+  // Find if the asset has been already loaded, if so return a pointer to it.
+  {
+    const auto lk       = std::lock_guard<std::mutex>{m_assetsMutex};
+    const auto assetItr = m_assets.find(id);
+    if (assetItr != m_assets.end()) {
+      return assetItr->second.get();
+    }
+  }
+
+  auto loadBeginTime = Clock::now();
+
+  const auto path = getPath(id);
+  AssetUnique asset;
+  try {
+    auto rawData        = loadRaw(path);
+    const auto dataSize = rawData.size();
+
+    asset = internal::loadAsset(id, path, std::move(rawData), this);
+    assert(asset);
+
+    LOG_I(
+        m_logger,
+        "Asset loaded",
+        {"id", id},
+        {"path", path.string()},
+        {"kind", getName(asset->getKind())},
+        {"size", log::MemSize{dataSize}},
+        {"duration", Clock::now() - loadBeginTime});
+
+  } catch (const err::AssetLoadErr& err) {
+    LOG_W(
+        m_logger,
+        "Failed to load asset",
+        {"id", id},
+        {"reason", err.getInnerMsg()},
+        {"path", path.string()});
+    throw;
+  } catch (...) {
+    LOG_W(m_logger, "Failed to load asset", {"id", id}, {"path", path.string()});
+    throw;
+  }
+
+  // Save the asset in the map.
+  {
+    const auto lk = std::lock_guard<std::mutex>{m_assetsMutex};
+
+    // Note: Another insertion might have beaten us to it, but in that case we will just return a
+    // pointer to the previously inserted asset and discard our asset.
+    const auto assetItr = m_assets.insert({id, std::move(asset)});
+    return assetItr.first->second.get();
+  }
+}
+
+auto DatabaseImpl::getPath(const AssetId& id) const noexcept -> fs::path { return m_rootPath / id; }
+
+} // namespace tria::asset

--- a/src/tria/asset/database_impl.hpp
+++ b/src/tria/asset/database_impl.hpp
@@ -15,8 +15,11 @@ public:
   ~DatabaseImpl() = default;
 
   /* Get a pointer to an asset. Will either load it or return a previously loaded asset.
+   *
    * TODO(bastian): In the future this should probably return a 'smart-pointer'-like handle so we
    * can track who is using it so we can decide when to unload it.
+   *
+   * Throws if asset loading fails.
    */
   [[nodiscard]] auto get(const AssetId& id) -> const Asset*;
 

--- a/src/tria/asset/database_impl.hpp
+++ b/src/tria/asset/database_impl.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "tria/asset/database.hpp"
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace tria::asset {
+
+using AssetUnique = std::unique_ptr<Asset>;
+
+class DatabaseImpl final {
+public:
+  DatabaseImpl(log::Logger* logger, fs::path rootPath) :
+      m_logger{logger}, m_rootPath{std::move(rootPath)} {}
+  ~DatabaseImpl() = default;
+
+  /* Get a pointer to an asset. Will either load it or return a previously loaded asset.
+   * TODO(bastian): In the future this should probably return a 'smart-pointer'-like handle so we
+   * can track who is using it so we can decide when to unload it.
+   */
+  [[nodiscard]] auto get(const AssetId& id) -> const Asset*;
+
+private:
+  log::Logger* m_logger;
+  fs::path m_rootPath;
+
+  std::mutex m_assetsMutex;
+  std::unordered_map<AssetId, AssetUnique> m_assets;
+
+  [[nodiscard]] auto getPath(const AssetId& id) const noexcept -> fs::path;
+};
+
+} // namespace tria::asset

--- a/src/tria/asset/internal/graphic_loader.cpp
+++ b/src/tria/asset/internal/graphic_loader.cpp
@@ -1,0 +1,40 @@
+#include "json.hpp"
+#include "loader.hpp"
+#include "tria/asset/err/asset_load_err.hpp"
+#include "tria/asset/graphic.hpp"
+#include <string_view>
+
+namespace tria::asset::internal {
+
+auto loadGraphic(AssetId id, const fs::path& path, RawData raw, DatabaseImpl* db) -> AssetUnique {
+
+  simdjson::dom::object obj;
+  auto err = parseJson(raw).get(obj);
+  if (err) {
+    throw err::AssetLoadErr{path, error_message(err)};
+  }
+
+  // Vertex shader.
+  std::string_view vertShaderId;
+  if (obj.at("vertShader").get(vertShaderId)) {
+    throw err::AssetLoadErr{path, "No 'vertShader' field found on graphic"};
+  }
+  auto vertShader = db->get(AssetId{vertShaderId})->downcast<Shader>();
+  if (vertShader->getShaderKind() != ShaderKind::SpvVertex) {
+    throw err::AssetLoadErr{path, "Invalid vertex shader"};
+  }
+
+  // Fragment shader.
+  std::string_view fragShaderId;
+  if (obj.at("fragShader").get(fragShaderId)) {
+    throw err::AssetLoadErr{path, "No 'fragShader' field found on graphic"};
+  }
+  auto fragShader = db->get(AssetId{fragShaderId})->downcast<Shader>();
+  if (fragShader->getShaderKind() != ShaderKind::SpvFragment) {
+    throw err::AssetLoadErr{path, "Invalid fragment shader"};
+  }
+
+  return std::make_unique<Graphic>(std::move(id), vertShader, fragShader);
+}
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/json.cpp
+++ b/src/tria/asset/internal/json.cpp
@@ -1,0 +1,10 @@
+#include "json.hpp"
+
+namespace tria::asset::internal {
+
+auto parseJson(const std::vector<char>& raw) noexcept -> JsonParseResult {
+  thread_local static simdjson::dom::parser parser;
+  return parser.parse(raw.data(), raw.size(), true);
+}
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/json.hpp
+++ b/src/tria/asset/internal/json.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "simdjson.h"
+#include <vector>
+
+namespace tria::asset::internal {
+
+using JsonParseResult = simdjson::simdjson_result<simdjson::dom::element>;
+
+/*
+ * Parse a json file.
+ * Note: Return value can be used until the next call to 'parseJson' on the same thread.
+ * Safe to be called concurrently but results should not be shared among threads.
+ */
+[[nodiscard]] auto parseJson(const std::vector<char>& raw) noexcept -> JsonParseResult;
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/loader.cpp
+++ b/src/tria/asset/internal/loader.cpp
@@ -3,6 +3,7 @@
 
 namespace tria::asset::internal {
 
+auto loadGraphic(AssetId, const fs::path&, RawData, DatabaseImpl*) -> AssetUnique;
 auto loadShader(AssetId, const fs::path&, RawData, DatabaseImpl*) -> AssetUnique;
 auto loadRawAsset(AssetId, const fs::path&, RawData, DatabaseImpl*) -> AssetUnique;
 
@@ -10,6 +11,7 @@ namespace {
 
 auto getLoader(const fs::path& path) -> AssetLoader {
   static const std::unordered_map<std::string, AssetLoader> table = {
+      {".gfx", loadGraphic},
       {".spv", loadShader},
   };
   auto itr = table.find(path.extension().string());

--- a/src/tria/asset/internal/loader.cpp
+++ b/src/tria/asset/internal/loader.cpp
@@ -1,0 +1,30 @@
+#include "loader.hpp"
+#include <cassert>
+
+namespace tria::asset::internal {
+
+auto loadShader(AssetId, const fs::path&, RawData, DatabaseImpl*) -> AssetUnique;
+auto loadRawAsset(AssetId, const fs::path&, RawData, DatabaseImpl*) -> AssetUnique;
+
+namespace {
+
+auto getLoader(const fs::path& path) -> AssetLoader {
+  static const std::unordered_map<std::string, AssetLoader> table = {
+      {".spv", loadShader},
+  };
+  auto itr = table.find(path.extension().string());
+  if (itr != table.end()) {
+    return itr->second;
+  }
+  // If no loader was found for the extension we fallback to the raw-asset loader.
+  return loadRawAsset;
+}
+
+} // namespace
+
+auto loadAsset(AssetId id, const fs::path& path, RawData raw, DatabaseImpl* db) -> AssetUnique {
+  assert(db);
+  return getLoader(path)(std::move(id), path, std::move(raw), db);
+}
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/loader.hpp
+++ b/src/tria/asset/internal/loader.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "../database_impl.hpp"
+#include "tria/fs.hpp"
+
+namespace tria::asset::internal {
+
+using RawData     = std::vector<char>;
+using AssetLoader = AssetUnique (*)(AssetId id, const fs::path& path, RawData, DatabaseImpl*);
+
+[[nodiscard]] auto loadAsset(AssetId id, const fs::path& path, RawData raw, DatabaseImpl* db)
+    -> AssetUnique;
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/raw_asset_loader.cpp
+++ b/src/tria/asset/internal/raw_asset_loader.cpp
@@ -1,0 +1,11 @@
+#include "loader.hpp"
+#include "tria/asset/raw_asset.hpp"
+
+namespace tria::asset::internal {
+
+auto loadRawAsset(AssetId id, const fs::path& /*unused*/, RawData raw, DatabaseImpl * /*unused*/)
+    -> AssetUnique {
+  return std::make_unique<RawAsset>(std::move(id), std::move(raw));
+}
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/shader_loader.cpp
+++ b/src/tria/asset/internal/shader_loader.cpp
@@ -1,0 +1,38 @@
+#include "loader.hpp"
+#include "tria/asset/err/asset_load_err.hpp"
+#include "tria/asset/shader.hpp"
+#include <optional>
+#include <string_view>
+
+namespace tria::asset::internal {
+
+namespace {
+
+auto endsWith(const std::string& str, const std::string_view suffix) noexcept {
+  return str.size() >= suffix.size() &&
+      str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+[[nodiscard]] auto getShaderKind(const fs::path& path) noexcept -> std::optional<ShaderKind> {
+  auto str = path.string();
+  if (endsWith(str, ".vert.spv")) {
+    return ShaderKind::SpvVertex;
+  }
+  if (endsWith(str, ".frag.spv")) {
+    return ShaderKind::SpvFragment;
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+auto loadShader(AssetId id, const fs::path& path, RawData raw, DatabaseImpl * /*unused*/)
+    -> AssetUnique {
+  auto shaderKind = getShaderKind(path);
+  if (!shaderKind) {
+    throw err::AssetLoadErr{path, "Unable to determine shader type"};
+  }
+  return std::make_unique<Shader>(std::move(id), *shaderKind, std::move(raw));
+}
+
+} // namespace tria::asset::internal

--- a/src/tria/log/logger.cpp
+++ b/src/tria/log/logger.cpp
@@ -55,7 +55,7 @@ private:
   std::condition_variable m_logCondVar;
 
   auto logLoop() noexcept -> void {
-    pal::setThreadName("log_thread");
+    pal::setThreadName("tria_log_thread");
 
     auto running = true;
     while (running) {

--- a/src/tria/pal/interrupt.linux.cpp
+++ b/src/tria/pal/interrupt.linux.cpp
@@ -6,7 +6,7 @@ namespace tria::pal {
 
 std::atomic_bool g_interruptRequested = false;
 
-auto interruptHandler(int /*unused*/) -> void {
+auto interruptHandler(int /*unused*/) noexcept -> void {
   g_interruptRequested.store(true, std::memory_order_release);
 }
 

--- a/src/tria/pal/interrupt.win32.cpp
+++ b/src/tria/pal/interrupt.win32.cpp
@@ -6,7 +6,7 @@ namespace tria::pal {
 
 std::atomic_bool g_interruptRequested = false;
 
-auto interruptHandler(DWORD dwCtrlType) -> int {
+auto interruptHandler(DWORD dwCtrlType) noexcept -> int {
   switch (dwCtrlType) {
   case CTRL_C_EVENT:
   case CTRL_BREAK_EVENT:

--- a/src/tria/pal/utils.win32.cpp
+++ b/src/tria/pal/utils.win32.cpp
@@ -2,24 +2,25 @@
 #include <array>
 #include <codecvt>
 #include <locale>
+#include <string_view>
 #include <windows.h>
 
 namespace tria::pal {
 
 namespace {
 
-auto errorExit(const char* msg) {
+auto errorExit(const char* msg) noexcept {
   std::fprintf(stderr, "%s\n", msg);
   std::fflush(stderr);
   std::exit(EXIT_FAILURE);
 }
 
-auto endsWith(const std::string& str, const std::string& suffix) {
+auto endsWith(const std::string& str, const std::string_view suffix) noexcept {
   return str.size() >= suffix.size() &&
       str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
-auto enableVTConsoleMode() -> bool {
+auto enableVTConsoleMode() noexcept -> bool {
   auto hOut = GetStdHandle(STD_OUTPUT_HANDLE);
   if (hOut == INVALID_HANDLE_VALUE) {
     return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,9 @@ include(Catch)
 # 'tria_tests' executable.
 message(STATUS "Configuring tria_tests executable")
 add_executable(tria_tests
+  tria/asset/database_test.cpp
+  tria/asset/shader_test.cpp
+
   tria/log/level_test.cpp
   tria/log/logger_test.cpp
   tria/log/param_test.cpp
@@ -23,7 +26,9 @@ add_executable(tria_tests
   tria/main.cpp)
 target_compile_features(tria_tests PUBLIC cxx_std_17)
 target_link_libraries(tria_tests PRIVATE Catch2::Catch2)
+target_link_libraries(tria_tests PRIVATE tria_asset)
 target_link_libraries(tria_tests PRIVATE tria_log)
+target_link_libraries(tria_tests PRIVATE tria_pal)
 
 # Register tests to CTest.
 message(STATUS "Registering tests to CTest")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ message(STATUS "Configuring tria_tests executable")
 add_executable(tria_tests
   tria/asset/database_test.cpp
   tria/asset/shader_test.cpp
+  tria/asset/utils.cpp
 
   tria/log/level_test.cpp
   tria/log/logger_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,9 @@ FetchContent_MakeAvailable(catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
+# Enable linting, add external code above this line.
+enable_linting()
+
 # 'tria_tests' executable.
 message(STATUS "Configuring tria_tests executable")
 add_executable(tria_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(FetchContent)
 
-# 'Catch2' testing framework.
+# External: 'Catch2' testing framework.
 message(STATUS "Fetching dependency: catch2")
 FetchContent_Declare(
   catch2
@@ -15,6 +15,7 @@ include(Catch)
 message(STATUS "Configuring tria_tests executable")
 add_executable(tria_tests
   tria/asset/database_test.cpp
+  tria/asset/graphic_test.cpp
   tria/asset/shader_test.cpp
   tria/asset/utils.cpp
 

--- a/tests/tria/asset/database_test.cpp
+++ b/tests/tria/asset/database_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("[asset] - Database", "[asset]") {
   }
 
   SECTION("Assets can be loaded in parallel") {
-    constexpr static int numFiles          = 250;
+    constexpr static int numFiles          = 100;
     constexpr static int numThreads        = 10;
     constexpr static int numLoadsPerThread = 1'000;
 

--- a/tests/tria/asset/database_test.cpp
+++ b/tests/tria/asset/database_test.cpp
@@ -1,0 +1,85 @@
+#include "catch2/catch.hpp"
+#include "tria/asset/database.hpp"
+#include "tria/asset/err/asset_load_err.hpp"
+#include "tria/asset/err/asset_type_err.hpp"
+#include "tria/asset/shader.hpp"
+#include "utils.hpp"
+#include <random>
+#include <thread>
+#include <tuple>
+
+namespace tria::asset::tests {
+
+TEST_CASE("[asset] - Database", "[asset]") {
+
+  SECTION("Loading asset yields its contents") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.tst", "Hello World");
+
+      auto db = Database{nullptr, dir};
+      CHECK_RAW_ASSET(db.get("test.tst"), "Hello World");
+
+      // Load the same file again, content should be the same.
+      CHECK_RAW_ASSET(db.get("test.tst"), "Hello World");
+    });
+  }
+
+  SECTION("Downcasting to an incorrect type throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.tst", "Hello World");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.tst")->downcast<Shader>(), err::AssetTypeErr);
+    });
+  }
+
+  SECTION("Loading non-existing asset throws") {
+    withTempDir([](const fs::path& dir) {
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("nothing.txt"), err::AssetLoadErr);
+    });
+  }
+
+  SECTION("Assets can be loaded in parallel") {
+    constexpr static int numFiles          = 250;
+    constexpr static int numThreads        = 10;
+    constexpr static int numLoadsPerThread = 1'000;
+
+    withTempDir([](const fs::path& dir) {
+      auto db = Database{nullptr, dir};
+
+      // Generate test files.
+      auto files = std::vector<std::tuple<std::string, std::string>>();
+      for (auto fileNum = 0U; fileNum != numFiles; ++fileNum) {
+        const auto fileNumStr  = std::to_string(fileNum);
+        const auto filePath    = fileNumStr + ".tst";
+        const auto fileContent = std::string{"Hello "} + fileNumStr;
+        writeFile(dir / filePath, fileContent);
+        files.push_back({filePath, fileContent});
+      }
+
+      // Load random files in parallel.
+      auto threads = std::vector<std::thread>{};
+      for (auto threadNum = 0U; threadNum != numThreads; ++threadNum) {
+        threads.push_back(std::thread{[&files, &db]() {
+          auto rngDev  = std::random_device{};
+          auto rngGen  = std::mt19937{rngDev()};
+          auto rngDist = std::uniform_int_distribution<size_t>{0, files.size() - 1};
+
+          for (auto loadNum = 0U; loadNum != numLoadsPerThread; ++loadNum) {
+            // Pick a random file and load it.
+            const auto& [id, content] = files[rngDist(rngGen)];
+            CHECK_RAW_ASSET(db.get(id), content);
+          }
+        }});
+      }
+
+      // Wait for all threads to finish.
+      for (auto& thread : threads) {
+        thread.join();
+      }
+    });
+  }
+}
+
+} // namespace tria::asset::tests

--- a/tests/tria/asset/graphic_test.cpp
+++ b/tests/tria/asset/graphic_test.cpp
@@ -1,0 +1,101 @@
+#include "catch2/catch.hpp"
+#include "tria/asset/database.hpp"
+#include "tria/asset/err/asset_load_err.hpp"
+#include "tria/asset/graphic.hpp"
+#include "utils.hpp"
+
+namespace tria::asset::tests {
+
+TEST_CASE("[asset] - Graphic", "[asset]") {
+
+  SECTION("Shaders are loaded as part of the graphic") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.vert.spv", "");
+      writeFile(dir / "test.frag.spv", "");
+      writeFile(
+          dir / "test.gfx",
+          "{"
+          "\"vertShader\": \"test.vert.spv\","
+          "\"fragShader\": \"test.frag.spv\""
+          "}");
+
+      auto db   = Database{nullptr, dir};
+      auto* gfx = db.get("test.gfx")->downcast<Graphic>();
+      CHECK(gfx->getVertShader()->getShaderKind() == ShaderKind::SpvVertex);
+      CHECK(gfx->getFragShader()->getShaderKind() == ShaderKind::SpvFragment);
+    });
+  }
+
+  SECTION("Loading a graphic with invalid json throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(
+          dir / "test.gfx",
+          "{"
+          "\"vertShader\": \"test.vert.spv\","
+          "\"fragShader\": \"test.frag.spv\"");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.gfx"), err::AssetLoadErr);
+    });
+  }
+
+  SECTION("Loading a graphic without a vertex shader throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.frag.spv", "");
+      writeFile(
+          dir / "test.gfx",
+          "{"
+          "\"fragShader\": \"test.frag.spv\""
+          "}");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.gfx"), err::AssetLoadErr);
+    });
+  }
+
+  SECTION("Loading a graphic without a fragment shader throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.vert.spv", "");
+      writeFile(
+          dir / "test.gfx",
+          "{"
+          "\"vertShader\": \"test.vert.spv\""
+          "}");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.gfx"), err::AssetLoadErr);
+    });
+  }
+
+  SECTION("Loading a graphic with incorrect vertex shader type throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.frag.spv", "");
+      writeFile(
+          dir / "test.gfx",
+          "{"
+          "\"vertShader\": \"test.frag.spv\","
+          "\"fragShader\": \"test.frag.spv\""
+          "}");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.gfx"), err::AssetLoadErr);
+    });
+  }
+
+  SECTION("Loading a graphic with incorrect fragment shader type throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.vert.spv", "");
+      writeFile(
+          dir / "test.gfx",
+          "{"
+          "\"vertShader\": \"test.vert.spv\","
+          "\"fragShader\": \"test.vert.spv\""
+          "}");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.gfx"), err::AssetLoadErr);
+    });
+  }
+}
+
+} // namespace tria::asset::tests

--- a/tests/tria/asset/shader_test.cpp
+++ b/tests/tria/asset/shader_test.cpp
@@ -1,0 +1,52 @@
+#include "catch2/catch.hpp"
+#include "tria/asset/database.hpp"
+#include "tria/asset/err/asset_load_err.hpp"
+#include "tria/asset/shader.hpp"
+#include "utils.hpp"
+
+namespace tria::asset::tests {
+
+TEST_CASE("[asset] - Shader", "[asset]") {
+
+  SECTION("Spir-v vertex shaders are identified based on their name") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.vert.spv", "");
+
+      auto db = Database{nullptr, dir};
+      REQUIRE(db.get("test.vert.spv")->getKind() == AssetKind::Shader);
+      CHECK(db.get("test.vert.spv")->downcast<Shader>()->getShaderKind() == ShaderKind::SpvVertex);
+    });
+  }
+
+  SECTION("Spir-v fragment shaders are identified based on their name") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.frag.spv", "");
+
+      auto db = Database{nullptr, dir};
+      REQUIRE(db.get("test.frag.spv")->getKind() == AssetKind::Shader);
+      CHECK(
+          db.get("test.frag.spv")->downcast<Shader>()->getShaderKind() == ShaderKind::SpvFragment);
+    });
+  }
+
+  SECTION("Loading spir-v shader with unexpected name throws") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.spv", "");
+
+      auto db = Database{nullptr, dir};
+      CHECK_THROWS_AS(db.get("test.spv"), err::AssetLoadErr);
+    });
+  }
+
+  SECTION("Loading spir-v shader yields its contents") {
+    withTempDir([](const fs::path& dir) {
+      writeFile(dir / "test.vert.spv", "Hello Shader");
+
+      auto db      = Database{nullptr, dir};
+      auto* shader = db.get("test.vert.spv")->downcast<Shader>();
+      CHECK(std::string(shader->getData(), shader->getSize()) == "Hello Shader");
+    });
+  }
+}
+
+} // namespace tria::asset::tests

--- a/tests/tria/asset/utils.cpp
+++ b/tests/tria/asset/utils.cpp
@@ -1,0 +1,34 @@
+#include "utils.hpp"
+#include "tria/fs.hpp"
+#include <fstream>
+
+#if defined(__MINGW32__)
+#include <windows.h>
+#endif
+
+namespace tria::asset::tests {
+
+auto writeFile(const fs::path& path, std::string data) -> void {
+  auto file = std::ofstream{path.string(), std::ios::out | std::ios::binary};
+  file.write(data.data(), data.length());
+  file.close();
+}
+
+auto deleteDir(const fs::path& path) -> void {
+#if defined(__MINGW32__)
+  // At the time of writing the remove_all that ships with MinGW fails when deleting a directory
+  // with content. It actually succeeds to delete the nested content but then fails to delete the
+  // directory itself. As a workaround we delete the directory with the win32 'RemoveDirectory'.
+  try {
+    fs::remove_all(path);
+  } catch (...) {
+    if (!RemoveDirectoryW(path.wstring().data())) {
+      throw;
+    }
+  }
+#else
+  fs::remove_all(path);
+#endif
+}
+
+} // namespace tria::asset::tests

--- a/tests/tria/asset/utils.hpp
+++ b/tests/tria/asset/utils.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "tria/asset/raw_asset.hpp"
+#include "tria/fs.hpp"
+#include "tria/pal/utils.hpp"
+#include <fstream>
+#include <string>
+
+namespace tria::asset::tests {
+
+inline auto writeFile(const fs::path& path, std::string data) {
+  auto file = std::ofstream{path.string(), std::ios::out | std::ios::binary};
+  file.write(data.data(), data.length());
+}
+
+template <typename TestFunc>
+auto withTempDir(TestFunc func) {
+  auto tmpDir = pal::getCurExecutablePath().parent_path() / "tria_asset_test";
+  fs::create_directories(tmpDir);
+  try {
+    func(tmpDir);
+    fs::remove_all(tmpDir);
+  } catch (...) {
+    fs::remove_all(tmpDir);
+    throw;
+  }
+}
+
+#define CHECK_RAW_ASSET(asset, expected)                                                           \
+  do {                                                                                             \
+    auto* assetPtr = asset;                                                                        \
+    REQUIRE(assetPtr->getKind() == AssetKind::Raw);                                                \
+    auto contentStr = std::string(                                                                 \
+        assetPtr->downcast<RawAsset>()->getData(), assetPtr->downcast<RawAsset>()->getSize());     \
+    auto expectedStr = std::string{expected};                                                      \
+    CHECK(contentStr == expectedStr);                                                              \
+  } while (false)
+
+} // namespace tria::asset::tests

--- a/tests/tria/asset/utils.hpp
+++ b/tests/tria/asset/utils.hpp
@@ -2,15 +2,12 @@
 #include "tria/asset/raw_asset.hpp"
 #include "tria/fs.hpp"
 #include "tria/pal/utils.hpp"
-#include <fstream>
 #include <string>
 
 namespace tria::asset::tests {
 
-inline auto writeFile(const fs::path& path, std::string data) {
-  auto file = std::ofstream{path.string(), std::ios::out | std::ios::binary};
-  file.write(data.data(), data.length());
-}
+auto writeFile(const fs::path& path, std::string data) -> void;
+auto deleteDir(const fs::path& path) -> void;
 
 template <typename TestFunc>
 auto withTempDir(TestFunc func) {
@@ -18,9 +15,9 @@ auto withTempDir(TestFunc func) {
   fs::create_directories(tmpDir);
   try {
     func(tmpDir);
-    fs::remove_all(tmpDir);
+    deleteDir(tmpDir);
   } catch (...) {
-    fs::remove_all(tmpDir);
+    deleteDir(tmpDir);
     throw;
   }
 }

--- a/tests/tria/log/level_test.cpp
+++ b/tests/tria/log/level_test.cpp
@@ -3,16 +3,16 @@
 
 namespace tria::log::tests {
 
-TEST_CASE("Log level", "[log]") {
+TEST_CASE("[log] - Log level", "[log]") {
 
-  SECTION("Level names") {
+  SECTION("Log levels have names") {
     CHECK(getName(Level::Debug) == std::string{"dbg"});
     CHECK(getName(Level::Info) == std::string{"inf"});
     CHECK(getName(Level::Warn) == std::string{"wrn"});
     CHECK(getName(Level::Error) == std::string{"err"});
   }
 
-  SECTION("Level mask") {
+  SECTION("Level mask can be used to filter levels") {
     const auto mask = Level::Error | Level::Debug;
     CHECK(isInMask(mask, Level::Error));
     CHECK(isInMask(mask, Level::Debug));

--- a/tests/tria/log/logger_test.cpp
+++ b/tests/tria/log/logger_test.cpp
@@ -5,9 +5,9 @@
 
 namespace tria::log::tests {
 
-TEST_CASE("Logger", "[log]") {
+TEST_CASE("[log] - Logger", "[log]") {
 
-  SECTION("Message publishing") {
+  SECTION("Published messages arrive to sink") {
     auto output = std::vector<Message>{};
     {
       auto logger    = Logger{makeMockSink(&output)};
@@ -38,7 +38,7 @@ TEST_CASE("Logger", "[log]") {
                                                   {"param4", std::string{"dyn_string"}}}));
   }
 
-  SECTION("Multithreaded publishing") {
+  SECTION("Messages can be published in parallel") {
     constexpr static int numThreads          = 5;
     constexpr static int numMessagePerThread = 10'000;
 

--- a/tests/tria/log/param_test.cpp
+++ b/tests/tria/log/param_test.cpp
@@ -34,12 +34,12 @@ auto getRefTimeT(int year, int month, int day, int hour, int min, int sec) -> Ti
 
 } // namespace
 
-TEST_CASE("Log write param", "[log]") {
+TEST_CASE("[log] - Log parameters", "[log]") {
 
   using namespace std::chrono;
   using namespace std::literals;
 
-  SECTION("Pretty") {
+  SECTION("Parameters can be pretty printed") {
     CHECK(toStringPretty({"key", 42}) == "42");
     CHECK(toStringPretty({"key", 100'000'000}) == "100000000");
 
@@ -85,7 +85,7 @@ TEST_CASE("Log write param", "[log]") {
     CHECK(toStringPretty({"key", MemSize{424242}}) == "414.3 KiB");
   }
 
-  SECTION("Json") {
+  SECTION("Parameters can be json printed") {
     CHECK(toStringJson({"key", 42}) == "42");
     CHECK(toStringJson({"key", 100'000'000}) == "100000000");
 

--- a/tests/tria/pal/utils_test.cpp
+++ b/tests/tria/pal/utils_test.cpp
@@ -3,17 +3,17 @@
 
 namespace tria::pal::tests {
 
-TEST_CASE("Platform utils", "[pal]") {
+TEST_CASE("[pal] - Platform utils", "[pal]") {
 
-  SECTION("Executable path") {
+  SECTION("Path to executable ends with the executable name") {
     CHECK_THAT(
         getCurExecutablePath().string(),
         (Catch::EndsWith("tria_tests") || Catch::EndsWith("tria_tests.exe")));
   }
 
-  SECTION("Executable name") { CHECK(getCurExecutableName() == "tria_tests"); }
+  SECTION("Executable name can be retrieved") { CHECK(getCurExecutableName() == "tria_tests"); }
 
-  SECTION("Naming threads") {
+  SECTION("Thread name can be retrieved after successfully naming it") {
     auto name = std::string_view{"test_thread"};
     if (setThreadName(name)) {
       CHECK(getThreadName() == name);


### PR DESCRIPTION
Basic asset library for loading data. All loads are synchronous and no data can be unloaded at the moment.
Types of assets:
* RawAsset (all assets that do not have explicit support in the asset library).
* Shader (spir-v shader code).
* Graphic (currently contains a pointer to a vertex and a fragment shader).

Example usage:
```c++
auto assetDb = asset::Database{&logger, pal::getCurExecutablePath().parent_path()};
auto* asset = assetDb.get("triangle.gfx");
```

In the future instead of handing out raw pointers to the assets we should probably return some smart-pointer-like handle object so we can track the usage and unload the assets when they are no longer needed.

This adds a dependency to the [`simdjson`](https://github.com/simdjson/simdjson) json parsing library.