### PR TITLE
Initial draw object api

### DIFF
--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -1,3 +1,4 @@
+#include "tria/asset/database.hpp"
 #include "tria/gfx/context.hpp"
 #include "tria/log/api.hpp"
 #include "tria/pal/interrupt.hpp"
@@ -26,9 +27,12 @@ auto operator<<(std::ostream& out, const Duration& rhs) -> std::ostream& {
 
 auto runApp(log::Logger& logger, pal::Platform& platform) -> int {
 
+  auto assetDb    = asset::Database{&logger, pal::getCurExecutablePath().parent_path() / "data"};
   auto gfxContext = gfx::Context{&logger};
   auto mainWin    = platform.createWindow(512, 512);
   auto mainCanvas = gfxContext.createCanvas(&mainWin, false);
+
+  const auto* triangle = assetDb.get("triangle.gfx")->downcast<asset::Graphic>();
 
   auto frameBegin = Clock::now();
   while (!mainWin.getIsCloseRequested() && !pal::isInterruptRequested()) {
@@ -37,7 +41,7 @@ auto runApp(log::Logger& logger, pal::Platform& platform) -> int {
     platform.handleEvents();
 
     if (mainCanvas.drawBegin()) {
-      // Do some actual drawing here :)
+      mainCanvas.draw(triangle);
       mainCanvas.drawEnd();
     } else {
       // Unable to draw, possibly due to a minimized window.

--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -30,7 +30,7 @@ auto runApp(log::Logger& logger, pal::Platform& platform) -> int {
   auto assetDb    = asset::Database{&logger, pal::getCurExecutablePath().parent_path() / "data"};
   auto gfxContext = gfx::Context{&logger};
   auto mainWin    = platform.createWindow(512, 512);
-  auto mainCanvas = gfxContext.createCanvas(&mainWin, false);
+  auto mainCanvas = gfxContext.createCanvas(&mainWin, gfx::VSyncMode::Disable);
 
   const auto* triangle = assetDb.get("triangle.gfx")->downcast<asset::Graphic>();
   const auto* quad     = assetDb.get("quad.gfx")->downcast<asset::Graphic>();

--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -33,6 +33,7 @@ auto runApp(log::Logger& logger, pal::Platform& platform) -> int {
   auto mainCanvas = gfxContext.createCanvas(&mainWin, false);
 
   const auto* triangle = assetDb.get("triangle.gfx")->downcast<asset::Graphic>();
+  const auto* quad     = assetDb.get("quad.gfx")->downcast<asset::Graphic>();
 
   auto frameBegin = Clock::now();
   while (!mainWin.getIsCloseRequested() && !pal::isInterruptRequested()) {
@@ -41,7 +42,8 @@ auto runApp(log::Logger& logger, pal::Platform& platform) -> int {
     platform.handleEvents();
 
     if (mainCanvas.drawBegin()) {
-      mainCanvas.draw(triangle);
+      mainCanvas.draw(triangle, 3);
+      mainCanvas.draw(quad, 6);
       mainCanvas.drawEnd();
     } else {
       // Unable to draw, possibly due to a minimized window.

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -54,13 +54,15 @@ endfunction(configure_plainfiles)
 # Shaders.
 message(STATUS "Configuring shaders")
 configure_shaders(
-  triangle.vert
-  triangle.frag)
+  plain.frag
+  quad.vert
+  triangle.vert)
 
 # Plain files
 message(STATUS "Configuring plain files")
 configure_plainfiles(
-  triangle.gfx)
+  triangle.gfx
+  quad.gfx)
 
 # Wrapper dependency that depends on all types of data.
 add_custom_target(tria_data)

--- a/data/quad.gfx
+++ b/data/quad.gfx
@@ -1,4 +1,4 @@
 {
-  "vertShader": "shaders/triangle.vert.spv",
+  "vertShader": "shaders/quad.vert.spv",
   "fragShader": "shaders/plain.frag.spv"
 }

--- a/data/shaders/plain.frag
+++ b/data/shaders/plain.frag
@@ -5,6 +5,4 @@ layout(location = 0) in vec3 fragColor;
 
 layout(location = 0) out vec4 outColor;
 
-void main() {
-  outColor = vec4(fragColor, 1.0);
-}
+void main() { outColor = vec4(fragColor, 1.0); }

--- a/data/shaders/quad.vert
+++ b/data/shaders/quad.vert
@@ -1,0 +1,30 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+vec2 centerPos = vec2(0.4, 0);
+float scale    = 0.5;
+
+vec2 positions[6] = vec2[](
+    centerPos + vec2(-0.5, -0.5) * scale,
+    centerPos + vec2(0.5, 0.5) * scale,
+    centerPos + vec2(-0.5, 0.5) * scale,
+
+    centerPos + vec2(-0.5, -0.5) * scale,
+    centerPos + vec2(0.5, -0.5) * scale,
+    centerPos + vec2(0.5, 0.5) * scale);
+
+vec3 colors[6] = vec3[](
+    vec3(1.0, 0.0, 0.0),
+    vec3(0.0, 1.0, 0.0),
+    vec3(0.0, 0.0, 1.0),
+
+    vec3(1.0, 0.0, 0.0),
+    vec3(1.0, 1.0, 0.0),
+    vec3(0.0, 1.0, 0.0));
+
+layout(location = 0) out vec3 fragColor;
+
+void main() {
+  gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+  fragColor   = colors[gl_VertexIndex];
+}

--- a/data/shaders/triangle.vert
+++ b/data/shaders/triangle.vert
@@ -1,21 +1,19 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-vec2 positions[3] = vec2[](
-  vec2(0.0, -0.5),
-  vec2(0.5, 0.5),
-  vec2(-0.5, 0.5)
-);
+vec2 centerPos = vec2(-0.4, 0);
+float scale    = 0.5;
 
-vec3 colors[3] = vec3[](
-  vec3(1.0, 0.0, 0.0),
-  vec3(0.0, 1.0, 0.0),
-  vec3(0.0, 0.0, 1.0)
-);
+vec2 positions[3] = vec2[](
+    centerPos + vec2(0.0, -0.5) * scale,
+    centerPos + vec2(0.5, 0.5) * scale,
+    centerPos + vec2(-0.5, 0.5) * scale);
+
+vec3 colors[3] = vec3[](vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0), vec3(0.0, 0.0, 1.0));
 
 layout(location = 0) out vec3 fragColor;
 
 void main() {
   gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
-  fragColor = colors[gl_VertexIndex];
+  fragColor   = colors[gl_VertexIndex];
 }

--- a/include/tria/gfx/canvas.hpp
+++ b/include/tria/gfx/canvas.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "tria/asset/graphic.hpp"
+#include <cstdint>
 #include <memory>
 
 namespace tria::gfx {
@@ -31,7 +32,7 @@ public:
 
   /* Draw a single instance of the given graphic.
    */
-  auto draw(const asset::Graphic* asset) -> void;
+  auto draw(const asset::Graphic* asset, uint16_t vertexCount) -> void;
 
   /* End drawing and present the result to the window.
    * Note: Has to be preceeded by a call to 'drawBegin'

--- a/include/tria/gfx/canvas.hpp
+++ b/include/tria/gfx/canvas.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "tria/asset/graphic.hpp"
 #include <memory>
 
 namespace tria::gfx {
@@ -27,6 +28,10 @@ public:
    * Returns: false if we failed to begin drawing (for example because the window is minimized).
    */
   [[nodiscard]] auto drawBegin() -> bool;
+
+  /* Draw a single instance of the given graphic.
+   */
+  auto draw(const asset::Graphic* asset) -> void;
 
   /* End drawing and present the result to the window.
    * Note: Has to be preceeded by a call to 'drawBegin'

--- a/include/tria/gfx/context.hpp
+++ b/include/tria/gfx/context.hpp
@@ -7,6 +7,8 @@ namespace tria::gfx {
 
 class NativeContext;
 
+enum class VSyncMode { Disable, Enable };
+
 /*
  * Abstraction over a graphics context.
  *
@@ -24,7 +26,7 @@ public:
 
   /* Create a canvas to render into that outputs to the given window.
    */
-  [[nodiscard]] auto createCanvas(const pal::Window* window, bool vSync) -> Canvas;
+  [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync) -> Canvas;
 
 private:
   std::unique_ptr<NativeContext> m_native;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,8 @@ message(STATUS "Configuring gfx vulkan library")
 add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/debug_messenger.cpp
   tria/gfx_vulkan/internal/device.cpp
+  tria/gfx_vulkan/internal/graphic.cpp
+  tria/gfx_vulkan/internal/graphic_manager.cpp
   tria/gfx_vulkan/internal/renderer.cpp
   tria/gfx_vulkan/internal/swapchain.cpp
   tria/gfx_vulkan/internal/utils.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/graphic.cpp
   tria/gfx_vulkan/internal/graphic_manager.cpp
   tria/gfx_vulkan/internal/renderer.cpp
+  tria/gfx_vulkan/internal/shader.cpp
+  tria/gfx_vulkan/internal/shader_manager.cpp
   tria/gfx_vulkan/internal/swapchain.cpp
   tria/gfx_vulkan/internal/utils.cpp
   tria/gfx_vulkan/context.cpp

--- a/src/tria/gfx_vulkan/canvas.cpp
+++ b/src/tria/gfx_vulkan/canvas.cpp
@@ -9,7 +9,9 @@ Canvas::~Canvas() = default;
 
 auto Canvas::drawBegin() -> bool { return m_native->drawBegin(); }
 
-auto Canvas::draw(const asset::Graphic* asset) -> void { m_native->draw(asset); }
+auto Canvas::draw(const asset::Graphic* asset, uint16_t vertexCount) -> void {
+  m_native->draw(asset, vertexCount);
+}
 
 auto Canvas::drawEnd() -> void { m_native->drawEnd(); }
 

--- a/src/tria/gfx_vulkan/canvas.cpp
+++ b/src/tria/gfx_vulkan/canvas.cpp
@@ -1,5 +1,5 @@
-#include "native_canvas.hpp"
 #include "tria/gfx/canvas.hpp"
+#include "native_canvas.hpp"
 
 namespace tria::gfx {
 
@@ -8,6 +8,8 @@ Canvas::Canvas(std::unique_ptr<NativeCanvas> native) : m_native{std::move(native
 Canvas::~Canvas() = default;
 
 auto Canvas::drawBegin() -> bool { return m_native->drawBegin(); }
+
+auto Canvas::draw(const asset::Graphic* asset) -> void { m_native->draw(asset); }
 
 auto Canvas::drawEnd() -> void { m_native->drawEnd(); }
 

--- a/src/tria/gfx_vulkan/context.cpp
+++ b/src/tria/gfx_vulkan/context.cpp
@@ -8,7 +8,7 @@ Context::Context(log::Logger* logger) : m_native{std::make_unique<NativeContext>
 
 Context::~Context() = default;
 
-auto Context::createCanvas(const pal::Window* window, bool vSync) -> Canvas {
+auto Context::createCanvas(const pal::Window* window, VSyncMode vSync) -> Canvas {
   if (!window) {
     throw std::invalid_argument{"Window cannot be null"};
   }

--- a/src/tria/gfx_vulkan/internal/debug_messenger.cpp
+++ b/src/tria/gfx_vulkan/internal/debug_messenger.cpp
@@ -13,7 +13,7 @@ static auto vkDebugCallback(
 
   auto* messenger = static_cast<DebugMessenger*>(pUserData);
   messenger->handleMessage(messageSeverity, messageType, pCallbackData);
-  return VK_FALSE;
+  return false;
 }
 
 namespace {

--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -1,0 +1,159 @@
+#include "graphic.hpp"
+#include "renderer.hpp"
+#include "utils.hpp"
+#include <array>
+#include <cassert>
+
+namespace tria::gfx::internal {
+
+namespace {
+
+[[nodiscard]] auto createShaderModule(VkDevice vkDevice, const asset::Shader& asset) {
+  VkShaderModuleCreateInfo createInfo = {};
+  createInfo.sType                    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+  createInfo.codeSize                 = asset.getSize();
+  createInfo.pCode                    = reinterpret_cast<const uint32_t*>(asset.getData());
+  VkShaderModule result;
+  checkVkResult(vkCreateShaderModule(vkDevice, &createInfo, nullptr, &result));
+  return result;
+}
+
+[[nodiscard]] auto createPipelineLayout(VkDevice vkDevice) {
+  VkPipelineLayoutCreateInfo pipelineLayoutInfo = {};
+  pipelineLayoutInfo.sType                      = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+
+  VkPipelineLayout result;
+  checkVkResult(vkCreatePipelineLayout(vkDevice, &pipelineLayoutInfo, nullptr, &result));
+  return result;
+}
+
+[[nodiscard]] auto createPipeline(
+    VkDevice vkDevice,
+    VkRenderPass vkRenderPass,
+    VkPipelineLayout layout,
+    VkShaderModule vertShader,
+    VkShaderModule fragShader) {
+
+  VkPipelineShaderStageCreateInfo vertShaderStageInfo = {};
+  vertShaderStageInfo.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+  vertShaderStageInfo.stage  = VK_SHADER_STAGE_VERTEX_BIT;
+  vertShaderStageInfo.module = vertShader;
+  vertShaderStageInfo.pName  = "main";
+
+  VkPipelineShaderStageCreateInfo fragShaderStageInfo = {};
+  fragShaderStageInfo.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+  fragShaderStageInfo.stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+  fragShaderStageInfo.module = fragShader;
+  fragShaderStageInfo.pName  = "main";
+
+  std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages = {
+      vertShaderStageInfo, fragShaderStageInfo};
+
+  VkPipelineVertexInputStateCreateInfo vertexInputInfo = {};
+  vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+  VkPipelineInputAssemblyStateCreateInfo inputAssembly = {};
+  inputAssembly.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+  inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+  VkViewport viewport = {};
+  viewport.x          = 0.0f;
+  viewport.y          = 0.0f;
+  viewport.width      = 512;
+  viewport.height     = 512;
+  viewport.minDepth   = 0.0f;
+  viewport.maxDepth   = 1.0f;
+
+  VkExtent2D extent = {};
+  extent.width      = 512;
+  extent.height     = 512;
+
+  VkRect2D scissor = {};
+  scissor.offset   = {0, 0};
+  scissor.extent   = extent;
+
+  VkPipelineViewportStateCreateInfo viewportState = {};
+  viewportState.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+  viewportState.viewportCount = 1;
+  viewportState.pViewports    = &viewport;
+  viewportState.scissorCount  = 1;
+  viewportState.pScissors     = &scissor;
+
+  VkPipelineRasterizationStateCreateInfo rasterizer = {};
+  rasterizer.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+  rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+  rasterizer.lineWidth   = 1.0f;
+  rasterizer.cullMode    = VK_CULL_MODE_BACK_BIT;
+  rasterizer.frontFace   = VK_FRONT_FACE_CLOCKWISE;
+
+  VkPipelineMultisampleStateCreateInfo multisampling = {};
+  multisampling.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+  multisampling.sampleShadingEnable  = false;
+  multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+  VkPipelineColorBlendAttachmentState colorBlendAttachment = {};
+  colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+      VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+  colorBlendAttachment.blendEnable = false;
+
+  VkPipelineColorBlendStateCreateInfo colorBlending = {};
+  colorBlending.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+  colorBlending.logicOpEnable   = false;
+  colorBlending.logicOp         = VK_LOGIC_OP_COPY;
+  colorBlending.attachmentCount = 1;
+  colorBlending.pAttachments    = &colorBlendAttachment;
+
+  VkGraphicsPipelineCreateInfo pipelineInfo = {};
+  pipelineInfo.sType                        = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+  pipelineInfo.stageCount                   = shaderStages.size();
+  pipelineInfo.pStages                      = shaderStages.data();
+  pipelineInfo.pVertexInputState            = &vertexInputInfo;
+  pipelineInfo.pInputAssemblyState          = &inputAssembly;
+  pipelineInfo.pViewportState               = &viewportState;
+  pipelineInfo.pRasterizationState          = &rasterizer;
+  pipelineInfo.pMultisampleState            = &multisampling;
+  pipelineInfo.pDepthStencilState           = nullptr;
+  pipelineInfo.pColorBlendState             = &colorBlending;
+  pipelineInfo.pDynamicState                = nullptr;
+  pipelineInfo.layout                       = layout;
+  pipelineInfo.renderPass                   = vkRenderPass;
+  pipelineInfo.subpass                      = 0;
+
+  VkPipeline result;
+  checkVkResult(vkCreateGraphicsPipelines(vkDevice, nullptr, 1, &pipelineInfo, nullptr, &result));
+  return result;
+}
+
+} // namespace
+
+Graphic::Graphic(
+    log::Logger* logger,
+    const Device* device,
+    VkRenderPass vkRenderPass,
+    const asset::Graphic* asset) :
+    m_logger{logger}, m_device{device} {
+  assert(device);
+
+  // Create shaders.
+  m_vertShader = createShaderModule(m_device->getVkDevice(), *asset->getVertShader());
+  m_fragShader = createShaderModule(m_device->getVkDevice(), *asset->getFragShader());
+
+  // Create pipeline layout.
+  m_pipelineLayout = createPipelineLayout(m_device->getVkDevice());
+
+  // Create pipeline.
+  m_pipeline = createPipeline(
+      m_device->getVkDevice(), vkRenderPass, m_pipelineLayout, m_vertShader, m_fragShader);
+
+  LOG_D(m_logger, "Graphic pipline created", {"asset", asset->getId()});
+}
+
+Graphic::~Graphic() {
+  vkDestroyPipeline(m_device->getVkDevice(), m_pipeline, nullptr);
+  vkDestroyPipelineLayout(m_device->getVkDevice(), m_pipelineLayout, nullptr);
+
+  vkDestroyShaderModule(m_device->getVkDevice(), m_vertShader, nullptr);
+  vkDestroyShaderModule(m_device->getVkDevice(), m_fragShader, nullptr);
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -1,6 +1,7 @@
 #include "graphic.hpp"
 #include "renderer.hpp"
 #include "utils.hpp"
+#include "vulkan/vulkan_core.h"
 #include <array>
 #include <cassert>
 
@@ -56,21 +57,9 @@ namespace {
   inputAssembly.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
   inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
+  // Note: viewport and scissor are set dynamically at draw time.
   VkViewport viewport = {};
-  viewport.x          = 0.0f;
-  viewport.y          = 0.0f;
-  viewport.width      = 512;
-  viewport.height     = 512;
-  viewport.minDepth   = 0.0f;
-  viewport.maxDepth   = 1.0f;
-
-  VkExtent2D extent = {};
-  extent.width      = 512;
-  extent.height     = 512;
-
-  VkRect2D scissor = {};
-  scissor.offset   = {0, 0};
-  scissor.extent   = extent;
+  VkRect2D scissor    = {};
 
   VkPipelineViewportStateCreateInfo viewportState = {};
   viewportState.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
@@ -103,6 +92,13 @@ namespace {
   colorBlending.attachmentCount = 1;
   colorBlending.pAttachments    = &colorBlendAttachment;
 
+  std::array<VkDynamicState, 2> dynamicStates = {
+      VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+  VkPipelineDynamicStateCreateInfo dynamicStateInfo = {};
+  dynamicStateInfo.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+  dynamicStateInfo.dynamicStateCount = dynamicStates.size();
+  dynamicStateInfo.pDynamicStates    = dynamicStates.data();
+
   VkGraphicsPipelineCreateInfo pipelineInfo = {};
   pipelineInfo.sType                        = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
   pipelineInfo.stageCount                   = shaderStages.size();
@@ -114,7 +110,7 @@ namespace {
   pipelineInfo.pMultisampleState            = &multisampling;
   pipelineInfo.pDepthStencilState           = nullptr;
   pipelineInfo.pColorBlendState             = &colorBlending;
-  pipelineInfo.pDynamicState                = nullptr;
+  pipelineInfo.pDynamicState                = &dynamicStateInfo;
   pipelineInfo.layout                       = layout;
   pipelineInfo.renderPass                   = vkRenderPass;
   pipelineInfo.subpass                      = 0;

--- a/src/tria/gfx_vulkan/internal/graphic.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include "device.hpp"
+#include "tria/asset/graphic.hpp"
+#include "tria/log/api.hpp"
+#include <memory>
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+class Graphic final {
+public:
+  Graphic(
+      log::Logger* logger,
+      const Device* device,
+      VkRenderPass vkRenderPass,
+      const asset::Graphic* asset);
+  ~Graphic();
+
+  [[nodiscard]] auto getVkPipeline() const noexcept { return m_pipeline; }
+
+private:
+  log::Logger* m_logger;
+  const Device* m_device;
+  VkShaderModule m_vertShader;
+  VkShaderModule m_fragShader;
+  VkPipelineLayout m_pipelineLayout;
+  VkPipeline m_pipeline;
+};
+
+using GraphicUnique = std::unique_ptr<Graphic>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/graphic.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic.hpp
@@ -1,32 +1,35 @@
 #pragma once
-#include "device.hpp"
 #include "tria/asset/graphic.hpp"
 #include "tria/log/api.hpp"
-#include <memory>
 #include <vulkan/vulkan.h>
 
 namespace tria::gfx::internal {
+
+class Device;
+class ShaderManager;
 
 class Graphic final {
 public:
   Graphic(
       log::Logger* logger,
       const Device* device,
+      ShaderManager* shaderManager,
       VkRenderPass vkRenderPass,
       const asset::Graphic* asset);
+  Graphic(const Graphic& rhs) = delete;
+  Graphic(Graphic&& rhs)      = delete;
   ~Graphic();
 
-  [[nodiscard]] auto getVkPipeline() const noexcept { return m_pipeline; }
+  auto operator=(const Graphic& rhs) -> Graphic& = delete;
+  auto operator=(Graphic&& rhs) -> Graphic& = delete;
+
+  [[nodiscard]] auto getVkPipeline() const noexcept { return m_vkPipeline; }
 
 private:
   log::Logger* m_logger;
   const Device* m_device;
-  VkShaderModule m_vertShader;
-  VkShaderModule m_fragShader;
-  VkPipelineLayout m_pipelineLayout;
-  VkPipeline m_pipeline;
+  VkPipelineLayout m_vkPipelineLayout;
+  VkPipeline m_vkPipeline;
 };
-
-using GraphicUnique = std::unique_ptr<Graphic>;
 
 } // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/graphic_manager.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic_manager.cpp
@@ -8,13 +8,13 @@ auto GraphicManager::getGraphic(const asset::Graphic* asset, VkRenderPass vkRend
   // If we already have a graphic for the given asset then return that.
   const auto itr = m_data.find(asset);
   if (itr != m_data.end()) {
-    return *itr->second;
+    return itr->second;
   }
 
   // Otherwise construct a new graphic.
-  auto newGraphic      = std::make_unique<Graphic>(m_logger, m_device, vkRenderPass, asset);
-  const auto insertItr = m_data.insert({asset, std::move(newGraphic)});
-  return *insertItr.first->second;
+  const auto insertItr =
+      m_data.try_emplace(asset, m_logger, m_device, m_shaderManager, vkRenderPass, asset);
+  return insertItr.first->second;
 }
 
 } // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/graphic_manager.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic_manager.cpp
@@ -1,0 +1,20 @@
+#include "graphic_manager.hpp"
+
+namespace tria::gfx::internal {
+
+auto GraphicManager::getGraphic(const asset::Graphic* asset, VkRenderPass vkRenderPass) noexcept
+    -> const Graphic& {
+
+  // If we already have a graphic for the given asset then return that.
+  const auto itr = m_data.find(asset);
+  if (itr != m_data.end()) {
+    return *itr->second;
+  }
+
+  // Otherwise construct a new graphic.
+  auto newGraphic      = std::make_unique<Graphic>(m_logger, m_device, vkRenderPass, asset);
+  const auto insertItr = m_data.insert({asset, std::move(newGraphic)});
+  return *insertItr.first->second;
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/graphic_manager.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic_manager.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "device.hpp"
+#include "graphic.hpp"
+#include "tria/log/api.hpp"
+#include <memory>
+#include <unordered_map>
+
+namespace tria::gfx::internal {
+
+class GraphicManager final {
+public:
+  GraphicManager(log::Logger* logger, const Device* device) : m_logger{logger}, m_device{device} {}
+  ~GraphicManager() = default;
+
+  [[nodiscard]] auto getGraphic(const asset::Graphic* asset, VkRenderPass vkRenderPass) noexcept
+      -> const Graphic&;
+
+private:
+  log::Logger* m_logger;
+  const Device* m_device;
+  std::unordered_map<const asset::Graphic*, GraphicUnique> m_data;
+};
+
+using GraphicManagerUnique = std::unique_ptr<GraphicManager>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/graphic_manager.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic_manager.hpp
@@ -1,15 +1,22 @@
 #pragma once
-#include "device.hpp"
 #include "graphic.hpp"
 #include "tria/log/api.hpp"
+#include <cassert>
 #include <memory>
 #include <unordered_map>
 
 namespace tria::gfx::internal {
 
+class Device;
+class ShaderManager;
+
 class GraphicManager final {
 public:
-  GraphicManager(log::Logger* logger, const Device* device) : m_logger{logger}, m_device{device} {}
+  GraphicManager(log::Logger* logger, const Device* device, ShaderManager* shaderManager) :
+      m_logger{logger}, m_device{device}, m_shaderManager{shaderManager} {
+    assert(m_device);
+    assert(m_shaderManager);
+  }
   ~GraphicManager() = default;
 
   [[nodiscard]] auto getGraphic(const asset::Graphic* asset, VkRenderPass vkRenderPass) noexcept
@@ -18,7 +25,8 @@ public:
 private:
   log::Logger* m_logger;
   const Device* m_device;
-  std::unordered_map<const asset::Graphic*, GraphicUnique> m_data;
+  ShaderManager* m_shaderManager;
+  std::unordered_map<const asset::Graphic*, Graphic> m_data;
 };
 
 using GraphicManagerUnique = std::unique_ptr<GraphicManager>;

--- a/src/tria/gfx_vulkan/internal/renderer.cpp
+++ b/src/tria/gfx_vulkan/internal/renderer.cpp
@@ -139,10 +139,10 @@ auto Renderer::drawBegin(VkRenderPass vkRenderPass, VkFramebuffer vkFrameBuffer,
   setScissor(m_gfxVkCommandBuffer, extent);
 }
 
-auto Renderer::draw(const Graphic& graphic) -> void {
+auto Renderer::draw(const Graphic& graphic, uint16_t vertexCount) -> void {
 
   vkCmdBindPipeline(m_gfxVkCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphic.getVkPipeline());
-  vkCmdDraw(m_gfxVkCommandBuffer, 3, 1, 0, 0);
+  vkCmdDraw(m_gfxVkCommandBuffer, vertexCount, 1, 0, 0);
 }
 
 auto Renderer::drawEnd() -> void {

--- a/src/tria/gfx_vulkan/internal/renderer.cpp
+++ b/src/tria/gfx_vulkan/internal/renderer.cpp
@@ -78,6 +78,24 @@ auto beginRenderPass(
   vkCmdBeginRenderPass(vkCommandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 }
 
+auto setViewport(VkCommandBuffer vkCommandBuffer, VkExtent2D extent) -> void {
+  VkViewport viewport = {};
+  viewport.x          = 0.0f;
+  viewport.y          = 0.0f;
+  viewport.width      = static_cast<float>(extent.width);
+  viewport.height     = static_cast<float>(extent.height);
+  viewport.minDepth   = 0.0f;
+  viewport.maxDepth   = 1.0f;
+  vkCmdSetViewport(vkCommandBuffer, 0, 1, &viewport);
+}
+
+auto setScissor(VkCommandBuffer vkCommandBuffer, VkExtent2D extent) -> void {
+  VkRect2D scissor = {};
+  scissor.offset   = {0, 0};
+  scissor.extent   = extent;
+  vkCmdSetScissor(vkCommandBuffer, 0, 1, &scissor);
+}
+
 } // namespace
 
 Renderer::Renderer(const Device* device) : m_device{device} {
@@ -115,6 +133,9 @@ auto Renderer::drawBegin(VkRenderPass vkRenderPass, VkFramebuffer vkFrameBuffer,
 
   beginCommandBuffer(m_gfxVkCommandBuffer);
   beginRenderPass(m_gfxVkCommandBuffer, vkRenderPass, vkFrameBuffer, extent);
+
+  setViewport(m_gfxVkCommandBuffer, extent);
+  setScissor(m_gfxVkCommandBuffer, extent);
 }
 
 auto Renderer::draw(const Graphic& graphic) -> void {

--- a/src/tria/gfx_vulkan/internal/renderer.cpp
+++ b/src/tria/gfx_vulkan/internal/renderer.cpp
@@ -1,4 +1,5 @@
 #include "renderer.hpp"
+#include "device.hpp"
 #include "utils.hpp"
 #include <array>
 #include <cassert>

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "device.hpp"
+#include "graphic.hpp"
 #include "tria/log/api.hpp"
 #include <vulkan/vulkan.h>
 
@@ -24,10 +25,18 @@ public:
    */
   [[nodiscard]] auto getImageFinished() const noexcept { return m_imgFinished; }
 
+  /* Wait until this rendering is ready to record a new frame.
+   */
+  auto waitUntilReady() -> void;
+
   /* Begin recording new draw commands to this renderer.
    * Note: Will block if the renderer is currently still rendering.
    */
   auto drawBegin(VkRenderPass vkRenderPass, VkFramebuffer vkFrameBuffer, VkExtent2D extent) -> void;
+
+  /* Record a single draw of the given graphic.
+   */
+  auto draw(const Graphic& graphic) -> void;
 
   /* Finish recordering draw commands and submit the work to the gpu.
    */

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -37,7 +37,7 @@ public:
 
   /* Record a single draw of the given graphic.
    */
-  auto draw(const Graphic& graphic) -> void;
+  auto draw(const Graphic& graphic, uint16_t vertexCount) -> void;
 
   /* Finish recordering draw commands and submit the work to the gpu.
    */

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -1,10 +1,11 @@
 #pragma once
-#include "device.hpp"
 #include "graphic.hpp"
 #include "tria/log/api.hpp"
 #include <vulkan/vulkan.h>
 
 namespace tria::gfx::internal {
+
+class Device;
 
 /*
  * Renderer is a handle to submit work to the gpu.

--- a/src/tria/gfx_vulkan/internal/shader.cpp
+++ b/src/tria/gfx_vulkan/internal/shader.cpp
@@ -1,0 +1,33 @@
+#include "shader.hpp"
+#include "device.hpp"
+#include "utils.hpp"
+#include <cassert>
+
+namespace tria::gfx::internal {
+
+namespace {
+
+[[nodiscard]] auto createShaderModule(VkDevice vkDevice, const asset::Shader& asset) {
+  VkShaderModuleCreateInfo createInfo = {};
+  createInfo.sType                    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+  createInfo.codeSize                 = asset.getSize();
+  createInfo.pCode                    = reinterpret_cast<const uint32_t*>(asset.getData());
+  VkShaderModule result;
+  checkVkResult(vkCreateShaderModule(vkDevice, &createInfo, nullptr, &result));
+  return result;
+}
+
+} // namespace
+
+Shader::Shader(log::Logger* logger, const Device* device, const asset::Shader* asset) :
+    m_logger{logger}, m_device{device} {
+  assert(device);
+
+  m_vkModule = createShaderModule(m_device->getVkDevice(), *asset);
+
+  LOG_D(m_logger, "Shader created", {"asset", asset->getId()});
+}
+
+Shader::~Shader() { vkDestroyShaderModule(m_device->getVkDevice(), m_vkModule, nullptr); }
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/shader.hpp
+++ b/src/tria/gfx_vulkan/internal/shader.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "tria/asset/shader.hpp"
+#include "tria/log/api.hpp"
+#include <memory>
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+class Device;
+
+class Shader final {
+public:
+  Shader(log::Logger* logger, const Device* device, const asset::Shader* asset);
+  Shader(const Shader& rhs) = delete;
+  Shader(Shader&& rhs)      = delete;
+  ~Shader();
+
+  auto operator=(const Shader& rhs) -> Shader& = delete;
+  auto operator=(Shader&& rhs) -> Shader& = delete;
+
+  [[nodiscard]] auto getVkModule() const noexcept { return m_vkModule; }
+
+private:
+  log::Logger* m_logger;
+  const Device* m_device;
+  VkShaderModule m_vkModule;
+};
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/shader_manager.cpp
+++ b/src/tria/gfx_vulkan/internal/shader_manager.cpp
@@ -1,0 +1,18 @@
+#include "shader_manager.hpp"
+
+namespace tria::gfx::internal {
+
+auto ShaderManager::getShader(const asset::Shader* asset) noexcept -> const Shader& {
+
+  // If we already have a shader for the given asset then return that.
+  const auto itr = m_data.find(asset);
+  if (itr != m_data.end()) {
+    return itr->second;
+  }
+
+  // Otherwise construct a new shader.
+  const auto insertItr = m_data.try_emplace(asset, m_logger, m_device, asset);
+  return insertItr.first->second;
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/shader_manager.hpp
+++ b/src/tria/gfx_vulkan/internal/shader_manager.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "shader.hpp"
+#include "tria/log/api.hpp"
+#include <cassert>
+#include <memory>
+#include <unordered_map>
+
+namespace tria::gfx::internal {
+
+class Device;
+
+class ShaderManager final {
+public:
+  ShaderManager(log::Logger* logger, const Device* device) : m_logger{logger}, m_device{device} {
+    assert(m_device);
+  }
+  ~ShaderManager() = default;
+
+  [[nodiscard]] auto getShader(const asset::Shader* asset) noexcept -> const Shader&;
+
+private:
+  log::Logger* m_logger;
+  const Device* m_device;
+  std::unordered_map<const asset::Shader*, Shader> m_data;
+};
+
+using ShaderManagerUnique = std::unique_ptr<ShaderManager>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/swapchain.cpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.cpp
@@ -194,6 +194,11 @@ auto Swapchain::acquireImage(VkRenderPass vkRenderPass, VkSemaphore imgAvailable
     }
   }
 
+  // Fail to acquire an image if the extent is 0 (can happen if the window is minized).
+  if (m_extent.width == 0 || m_extent.height == 0) {
+    return std::nullopt;
+  }
+
   uint32_t imgIndex;
   const auto result = vkAcquireNextImageKHR(
       m_device->getVkDevice(), m_vkSwapchain, UINT64_MAX, imgAvailable, nullptr, &imgIndex);

--- a/src/tria/gfx_vulkan/internal/swapchain.cpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.cpp
@@ -34,10 +34,11 @@ namespace {
   }
 }
 
-[[nodiscard]] auto getPresentMode(const Device* device, bool vSync) noexcept -> VkPresentModeKHR {
+[[nodiscard]] auto getPresentMode(const Device* device, VSyncMode vSync) noexcept
+    -> VkPresentModeKHR {
   assert(device);
   const auto modes = getVkPresentModes(device->getVkPhysicalDevice(), device->getVkSurface());
-  if (!vSync) {
+  if (vSync == VSyncMode::Disable) {
     // Prefer mailbox.
     for (const auto& mode : modes) {
       if (mode == VK_PRESENT_MODE_MAILBOX_KHR) {
@@ -74,8 +75,8 @@ namespace {
   createInfo.imageArrayLayers         = 1;
   createInfo.imageUsage               = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-  std::array<uint32_t, 2> queueFamilyIndices = {device->getVkGraphicsQueueIdx(),
-                                                device->getVkPresentQueueIdx()};
+  std::array<uint32_t, 2> queueFamilyIndices = {
+      device->getVkGraphicsQueueIdx(), device->getVkPresentQueueIdx()};
   if (queueFamilyIndices[0] == queueFamilyIndices[1]) {
     createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
   } else {
@@ -148,7 +149,7 @@ namespace {
 
 } // namespace
 
-Swapchain::Swapchain(log::Logger* logger, const Device* device, bool vSync) :
+Swapchain::Swapchain(log::Logger* logger, const Device* device, VSyncMode vSync) :
     m_logger{logger}, m_device{device}, m_vSync{vSync}, m_vkSwapchain{nullptr} {
   if (!m_device) {
     throw std::invalid_argument{"Device cannot be null"};

--- a/src/tria/gfx_vulkan/internal/swapchain.cpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.cpp
@@ -74,8 +74,8 @@ namespace {
   createInfo.imageArrayLayers         = 1;
   createInfo.imageUsage               = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-  std::array<uint32_t, 2> queueFamilyIndices = {device->getVkGraphicsQueueIdx(),
-                                                device->getVkPresentQueueIdx()};
+  std::array<uint32_t, 2> queueFamilyIndices = {
+      device->getVkGraphicsQueueIdx(), device->getVkPresentQueueIdx()};
   if (queueFamilyIndices[0] == queueFamilyIndices[1]) {
     createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
   } else {
@@ -90,7 +90,7 @@ namespace {
   createInfo.preTransform   = transformFlags;
   createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
   createInfo.presentMode    = presentMode;
-  createInfo.clipped        = VK_TRUE;
+  createInfo.clipped        = true;
   createInfo.oldSwapchain   = oldSwapchain;
 
   // Create a new swapchain.
@@ -196,7 +196,7 @@ auto Swapchain::acquireImage(VkRenderPass vkRenderPass, VkSemaphore imgAvailable
 
   uint32_t imgIndex;
   const auto result = vkAcquireNextImageKHR(
-      m_device->getVkDevice(), m_vkSwapchain, UINT64_MAX, imgAvailable, VK_NULL_HANDLE, &imgIndex);
+      m_device->getVkDevice(), m_vkSwapchain, UINT64_MAX, imgAvailable, nullptr, &imgIndex);
 
   switch (result) {
   case VK_ERROR_OUT_OF_DATE_KHR:

--- a/src/tria/gfx_vulkan/internal/swapchain.cpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.cpp
@@ -1,10 +1,10 @@
 #include "swapchain.hpp"
+#include "device.hpp"
 #include "utils.hpp"
 #include <array>
 #include <cassert>
 #include <cstdint>
 #include <stdexcept>
-#include <vulkan/vulkan_core.h>
 
 namespace tria::gfx::internal {
 
@@ -74,8 +74,8 @@ namespace {
   createInfo.imageArrayLayers         = 1;
   createInfo.imageUsage               = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-  std::array<uint32_t, 2> queueFamilyIndices = {
-      device->getVkGraphicsQueueIdx(), device->getVkPresentQueueIdx()};
+  std::array<uint32_t, 2> queueFamilyIndices = {device->getVkGraphicsQueueIdx(),
+                                                device->getVkPresentQueueIdx()};
   if (queueFamilyIndices[0] == queueFamilyIndices[1]) {
     createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
   } else {

--- a/src/tria/gfx_vulkan/internal/swapchain.hpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.hpp
@@ -1,11 +1,12 @@
 #pragma once
-#include "device.hpp"
 #include "tria/log/api.hpp"
 #include <optional>
 #include <vector>
 #include <vulkan/vulkan.h>
 
 namespace tria::gfx::internal {
+
+class Device;
 
 /*
  * Swapchain is responsible for managing the images that are presented to the surface (window).

--- a/src/tria/gfx_vulkan/internal/swapchain.hpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "tria/gfx/context.hpp"
 #include "tria/log/api.hpp"
 #include <optional>
 #include <vector>
@@ -13,7 +14,7 @@ class Device;
  */
 class Swapchain final {
 public:
-  Swapchain(log::Logger* logger, const Device* device, bool vSync);
+  Swapchain(log::Logger* logger, const Device* device, VSyncMode vSync);
   ~Swapchain();
 
   [[nodiscard]] auto getExtent() const noexcept { return m_extent; }
@@ -40,7 +41,7 @@ public:
 private:
   log::Logger* m_logger;
   const Device* m_device;
-  bool m_vSync;
+  VSyncMode m_vSync;
   unsigned int m_imgCount;
   VkExtent2D m_extent;
   VkSwapchainKHR m_vkSwapchain;

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -138,13 +138,13 @@ auto NativeCanvas::drawBegin() -> bool {
   return true;
 }
 
-auto NativeCanvas::draw(const asset::Graphic* asset) -> void {
+auto NativeCanvas::draw(const asset::Graphic* asset, uint16_t vertexCount) -> void {
   if (!m_curSwapchainImgIdx) {
     throw err::SyncErr{"Unable record a draw: no draw active"};
   }
 
   const auto& graphic = m_graphicManager->getGraphic(asset, m_vkRenderPass);
-  getCurRenderer().draw(graphic);
+  getCurRenderer().draw(graphic, vertexCount);
 }
 
 auto NativeCanvas::drawEnd() -> void {

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -76,7 +76,9 @@ NativeCanvas::NativeCanvas(
     throw err::DriverErr{"No device found with vulkan support"};
   }
 
-  m_graphicManager = std::make_unique<GraphicManager>(m_logger, m_device.get());
+  m_shaderManager = std::make_unique<ShaderManager>(m_logger, m_device.get());
+  m_graphicManager =
+      std::make_unique<GraphicManager>(m_logger, m_device.get(), m_shaderManager.get());
 
   m_vkRenderPass = createVkRenderPass(m_device.get());
 
@@ -92,6 +94,7 @@ NativeCanvas::~NativeCanvas() {
     m_renderers[i] = nullptr;
   }
   m_graphicManager = nullptr;
+  m_shaderManager  = nullptr;
   m_swapchain      = nullptr;
   vkDestroyRenderPass(m_device->getVkDevice(), m_vkRenderPass, nullptr);
   m_device = nullptr;

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -62,7 +62,7 @@ namespace {
 } // namespace
 
 NativeCanvas::NativeCanvas(
-    log::Logger* logger, const NativeContext* context, const pal::Window* window, bool vSync) :
+    log::Logger* logger, const NativeContext* context, const pal::Window* window, VSyncMode vSync) :
     m_logger{logger},
     m_context{context},
     m_window{window},

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -63,7 +63,11 @@ namespace {
 
 NativeCanvas::NativeCanvas(
     log::Logger* logger, const NativeContext* context, const pal::Window* window, bool vSync) :
-    m_logger{logger}, m_context{context}, m_window{window}, m_curSwapchainImgIdx{std::nullopt} {
+    m_logger{logger},
+    m_context{context},
+    m_window{window},
+    m_frontRenderer{false},
+    m_curSwapchainImgIdx{std::nullopt} {
   assert(m_context);
   assert(m_window);
 
@@ -71,6 +75,8 @@ NativeCanvas::NativeCanvas(
   if (!m_device) {
     throw err::DriverErr{"No device found with vulkan support"};
   }
+
+  m_graphicManager = std::make_unique<GraphicManager>(m_logger, m_device.get());
 
   m_vkRenderPass = createVkRenderPass(m_device.get());
 
@@ -85,7 +91,8 @@ NativeCanvas::~NativeCanvas() {
   for (auto i = 0U; i != m_renderers.size(); ++i) {
     m_renderers[i] = nullptr;
   }
-  m_swapchain = nullptr;
+  m_graphicManager = nullptr;
+  m_swapchain      = nullptr;
   vkDestroyRenderPass(m_device->getVkDevice(), m_vkRenderPass, nullptr);
   m_device = nullptr;
 }
@@ -108,6 +115,9 @@ auto NativeCanvas::drawBegin() -> bool {
   cycleRenderer();
   auto& curRenderer = getCurRenderer();
 
+  // Wait until this renderer is ready to record a new frame.
+  curRenderer.waitUntilReady();
+
   // Acquire an image to render into.
   const auto swapImgIdx =
       m_swapchain->acquireImage(m_vkRenderPass, curRenderer.getImageAvailable(), winHasResized);
@@ -123,6 +133,15 @@ auto NativeCanvas::drawBegin() -> bool {
       m_swapchain->getExtent());
 
   return true;
+}
+
+auto NativeCanvas::draw(const asset::Graphic* asset) -> void {
+  if (!m_curSwapchainImgIdx) {
+    throw err::SyncErr{"Unable record a draw: no draw active"};
+  }
+
+  const auto& graphic = m_graphicManager->getGraphic(asset, m_vkRenderPass);
+  getCurRenderer().draw(graphic);
 }
 
 auto NativeCanvas::drawEnd() -> void {

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -30,7 +30,7 @@ public:
 
   /* Record a draw with the given asset.
    */
-  auto draw(const asset::Graphic* asset) -> void;
+  auto draw(const asset::Graphic* asset, uint16_t vertexCount) -> void;
 
   /* Stop recording draw commands, execute the commands and present the result to the surface
    * (window).

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -4,6 +4,7 @@
 #include "internal/renderer.hpp"
 #include "internal/shader_manager.hpp"
 #include "internal/swapchain.hpp"
+#include "tria/gfx/context.hpp"
 #include "tria/log/api.hpp"
 #include "tria/pal/window.hpp"
 #include <array>
@@ -20,7 +21,10 @@ class NativeContext;
 class NativeCanvas final {
 public:
   NativeCanvas(
-      log::Logger* logger, const NativeContext* context, const pal::Window* window, bool vSync);
+      log::Logger* logger,
+      const NativeContext* context,
+      const pal::Window* window,
+      VSyncMode vSync);
   ~NativeCanvas();
 
   /* Begin recording draw commands.

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "internal/device.hpp"
+#include "internal/graphic_manager.hpp"
 #include "internal/renderer.hpp"
 #include "internal/swapchain.hpp"
 #include "tria/log/api.hpp"
@@ -26,6 +27,10 @@ public:
    */
   [[nodiscard]] auto drawBegin() -> bool;
 
+  /* Record a draw with the given asset.
+   */
+  auto draw(const asset::Graphic* asset) -> void;
+
   /* Stop recording draw commands, execute the commands and present the result to the surface
    * (window).
    */
@@ -36,6 +41,7 @@ private:
   const NativeContext* m_context;
   const pal::Window* m_window;
   internal::DeviceUnique m_device;
+  internal::GraphicManagerUnique m_graphicManager;
   VkRenderPass m_vkRenderPass;
   internal::SwapchainUnique m_swapchain;
 

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -2,6 +2,7 @@
 #include "internal/device.hpp"
 #include "internal/graphic_manager.hpp"
 #include "internal/renderer.hpp"
+#include "internal/shader_manager.hpp"
 #include "internal/swapchain.hpp"
 #include "tria/log/api.hpp"
 #include "tria/pal/window.hpp"
@@ -41,6 +42,7 @@ private:
   const NativeContext* m_context;
   const pal::Window* m_window;
   internal::DeviceUnique m_device;
+  internal::ShaderManagerUnique m_shaderManager;
   internal::GraphicManagerUnique m_graphicManager;
   VkRenderPass m_vkRenderPass;
   internal::SwapchainUnique m_swapchain;

--- a/src/tria/gfx_vulkan/native_context.cpp
+++ b/src/tria/gfx_vulkan/native_context.cpp
@@ -108,7 +108,7 @@ NativeContext::~NativeContext() {
   LOG_I(m_logger, "Vulkan instance destroyed");
 }
 
-auto NativeContext::createCanvas(const pal::Window* window, bool vSync)
+auto NativeContext::createCanvas(const pal::Window* window, VSyncMode vSync)
     -> std::unique_ptr<NativeCanvas> {
   return std::make_unique<NativeCanvas>(m_logger, this, window, vSync);
 }

--- a/src/tria/gfx_vulkan/native_context.hpp
+++ b/src/tria/gfx_vulkan/native_context.hpp
@@ -19,7 +19,7 @@ public:
 
   [[nodiscard]] auto getVkInstance() const noexcept { return m_vkInstance; }
 
-  [[nodiscard]] auto createCanvas(const pal::Window* window, bool vSync)
+  [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync)
       -> std::unique_ptr<NativeCanvas>;
 
 private:


### PR DESCRIPTION
Add an initial api to draw objects to the canvas. No meshes, textures or dynamic data of any kind yet. But you can write shaders and display them on the screen.
```c++
const auto* triangle = assetDb.get("triangle.gfx")->downcast<asset::Graphic>();
const auto* quad     = assetDb.get("quad.gfx")->downcast<asset::Graphic>();

...

if (mainCanvas.drawBegin()) {
  mainCanvas.draw(triangle, 3);
  mainCanvas.draw(quad, 6);
  mainCanvas.drawEnd();
}
```
Current output:
![image](https://user-images.githubusercontent.com/14230060/87583623-ee3c6500-c6e4-11ea-917f-4ba764b42a76.png)
