### PR TITLE
Memory transferer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/renderer.cpp
   tria/gfx_vulkan/internal/shader.cpp
   tria/gfx_vulkan/internal/swapchain.cpp
+  tria/gfx_vulkan/internal/transferer.cpp
   tria/gfx_vulkan/internal/utils.cpp
   tria/gfx_vulkan/context.cpp
   tria/gfx_vulkan/native_context.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(tria_asset PRIVATE Threads::Threads)
 # Gfx (graphics library).
 message(STATUS "Configuring gfx vulkan library")
 add_library(tria_gfx STATIC
+  tria/gfx_vulkan/internal/buffer.cpp
   tria/gfx_vulkan/internal/debug_messenger.cpp
   tria/gfx_vulkan/internal/device.cpp
   tria/gfx_vulkan/internal/graphic.cpp

--- a/src/tria/gfx_vulkan/internal/buffer.cpp
+++ b/src/tria/gfx_vulkan/internal/buffer.cpp
@@ -1,0 +1,80 @@
+#include "buffer.hpp"
+#include "utils.hpp"
+#include "vulkan/vulkan_core.h"
+#include <cassert>
+
+namespace tria::gfx::internal {
+
+namespace {
+
+[[nodiscard]] auto getVkBufferUsageFlags(BufferUsage usage) -> VkBufferUsageFlags {
+  switch (usage) {
+  case BufferUsage::VertexData:
+    return VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+  case BufferUsage::Transfer:
+    return VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+  }
+  throw err::DriverErr{"Unexpected buffer-usage"};
+}
+
+[[nodiscard]] auto getVkMemoryRequirements(VkDevice vkDevice, VkBuffer vkBuffer)
+    -> VkMemoryRequirements {
+  VkMemoryRequirements result;
+  vkGetBufferMemoryRequirements(vkDevice, vkBuffer, &result);
+  return result;
+}
+
+[[nodiscard]] auto createVkBuffer(VkDevice vkDevice, uint32_t size, VkBufferUsageFlags usageFlags)
+    -> VkBuffer {
+  VkBufferCreateInfo bufferInfo{};
+  bufferInfo.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+  bufferInfo.size        = size;
+  bufferInfo.usage       = usageFlags;
+  bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+  VkBuffer result;
+  checkVkResult(vkCreateBuffer(vkDevice, &bufferInfo, nullptr, &result));
+  return result;
+}
+
+} // namespace
+
+Buffer::Buffer(Device* device, size_t size, MemoryLocation location, BufferUsage usage) :
+    m_device{device} {
+  assert(m_device);
+
+  // Create a buffer.
+  auto usageFlags = getVkBufferUsageFlags(usage);
+  m_vkBuffer      = createVkBuffer(device->getVkDevice(), static_cast<uint32_t>(size), usageFlags);
+
+  // Allocate memory for it.
+  auto memoryRequirements = getVkMemoryRequirements(device->getVkDevice(), m_vkBuffer);
+  m_memory                = device->getMemory().allocate(location, memoryRequirements);
+
+  // Bind the memory to the buffer.
+  m_memory.bindToBuffer(m_vkBuffer);
+}
+
+Buffer::~Buffer() {
+  if (m_vkBuffer) {
+    vkDestroyBuffer(m_device->getVkDevice(), m_vkBuffer, nullptr);
+  }
+  // Note: Memory is reclaimed by the destructor of MemoryBlock.
+}
+
+auto Buffer::upload(const void* data, size_t size) -> void {
+  if (!m_vkBuffer) {
+    throw err::DriverErr{"Invalid buffer"};
+  }
+  if (size > m_memory.getSize()) {
+    throw err::DriverErr{"Buffer too small"};
+  }
+  auto* mappedPtr = m_memory.getMappedPtr();
+  if (!mappedPtr) {
+    throw err::DriverErr{"Unable to map buffer memory"};
+  }
+  std::memcpy(mappedPtr, data, size);
+  m_memory.flush();
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/buffer.cpp
+++ b/src/tria/gfx_vulkan/internal/buffer.cpp
@@ -10,7 +10,7 @@ namespace {
 [[nodiscard]] auto getVkBufferUsageFlags(BufferUsage usage) -> VkBufferUsageFlags {
   switch (usage) {
   case BufferUsage::VertexData:
-    return VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    return VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
   case BufferUsage::Transfer:
     return VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
   }
@@ -40,7 +40,7 @@ namespace {
 } // namespace
 
 Buffer::Buffer(Device* device, size_t size, MemoryLocation location, BufferUsage usage) :
-    m_device{device} {
+    m_device{device}, m_location{location} {
   assert(m_device);
 
   // Create a buffer.
@@ -62,14 +62,14 @@ Buffer::~Buffer() {
   // Note: Memory is reclaimed by the destructor of MemoryBlock.
 }
 
-auto Buffer::upload(const void* data, size_t size) -> void {
+auto Buffer::upload(const void* data, size_t size, uint32_t offset) -> void {
   if (!m_vkBuffer) {
     throw err::DriverErr{"Invalid buffer"};
   }
   if (size > m_memory.getSize()) {
     throw err::DriverErr{"Buffer too small"};
   }
-  auto* mappedPtr = m_memory.getMappedPtr();
+  auto* mappedPtr = m_memory.getMappedPtr() + offset;
   if (!mappedPtr) {
     throw err::DriverErr{"Unable to map buffer memory"};
   }

--- a/src/tria/gfx_vulkan/internal/buffer.hpp
+++ b/src/tria/gfx_vulkan/internal/buffer.hpp
@@ -18,29 +18,39 @@ public:
   Buffer() = default;
   Buffer(Device* device, size_t size, MemoryLocation loc, BufferUsage usage);
   Buffer(const Buffer& rhs) = delete;
-  Buffer(Buffer&& rhs)      = delete;
+  Buffer(Buffer&& rhs) noexcept {
+    m_device       = rhs.m_device;
+    m_location     = rhs.m_location;
+    m_vkBuffer     = rhs.m_vkBuffer;
+    m_memory       = std::move(rhs.m_memory);
+    rhs.m_vkBuffer = nullptr;
+  }
   ~Buffer();
 
   auto operator=(const Buffer& rhs) -> Buffer& = delete;
 
   auto operator=(Buffer&& rhs) noexcept -> Buffer& {
     m_device       = rhs.m_device;
+    m_location     = rhs.m_location;
     m_vkBuffer     = rhs.m_vkBuffer;
     m_memory       = std::move(rhs.m_memory);
-    rhs.m_vkBuffer = nullptr; // Indicate to the moved-from buffer that we will destroy it.
+    rhs.m_vkBuffer = nullptr;
     return *this;
   }
 
+  [[nodiscard]] auto getLocation() const noexcept { return m_location; }
   [[nodiscard]] auto getVkBuffer() const noexcept { return m_vkBuffer; }
+  [[nodiscard]] auto getSize() const noexcept { return m_memory.getSize(); }
 
   /* Upload data to the buffer.
    * Note: Only valid for buffers on the host (cpu) side. For gpu buffers an explicit transfer
    * operation has to be used.
    */
-  auto upload(const void* data, size_t size) -> void;
+  auto upload(const void* data, size_t size, uint32_t offset = 0U) -> void;
 
 private:
   const Device* m_device;
+  MemoryLocation m_location;
   VkBuffer m_vkBuffer;
   MemoryBlock m_memory;
 };

--- a/src/tria/gfx_vulkan/internal/buffer.hpp
+++ b/src/tria/gfx_vulkan/internal/buffer.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include "device.hpp"
+#include <cstdint>
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+enum class BufferUsage {
+  VertexData,
+  Transfer,
+};
+
+/* Data buffer.
+ * Either residing on the host (cpu) side or on the device (gpu) side.
+ */
+class Buffer final {
+public:
+  Buffer() = default;
+  Buffer(Device* device, size_t size, MemoryLocation loc, BufferUsage usage);
+  Buffer(const Buffer& rhs) = delete;
+  Buffer(Buffer&& rhs)      = delete;
+  ~Buffer();
+
+  auto operator=(const Buffer& rhs) -> Buffer& = delete;
+
+  auto operator=(Buffer&& rhs) noexcept -> Buffer& {
+    m_device       = rhs.m_device;
+    m_vkBuffer     = rhs.m_vkBuffer;
+    m_memory       = std::move(rhs.m_memory);
+    rhs.m_vkBuffer = nullptr; // Indicate to the moved-from buffer that we will destroy it.
+    return *this;
+  }
+
+  [[nodiscard]] auto getVkBuffer() const noexcept { return m_vkBuffer; }
+
+  /* Upload data to the buffer.
+   * Note: Only valid for buffers on the host (cpu) side. For gpu buffers an explicit transfer
+   * operation has to be used.
+   */
+  auto upload(const void* data, size_t size) -> void;
+
+private:
+  const Device* m_device;
+  VkBuffer m_vkBuffer;
+  MemoryBlock m_memory;
+};
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/memory_pool.cpp
+++ b/src/tria/gfx_vulkan/internal/memory_pool.cpp
@@ -7,8 +7,8 @@ namespace tria::gfx::internal {
 
 namespace {
 
-constexpr auto g_minChunkSize                   = 128 * 1024 * 1024;
-constexpr auto g_chunkInitialFreeBlocksCapacity = 100;
+constexpr auto g_minChunkSize                   = 64 * 1024 * 1024;
+constexpr auto g_chunkInitialFreeBlocksCapacity = 128;
 
 [[nodiscard]] auto getVkMemoryProperties(MemoryLocation loc) noexcept -> VkMemoryPropertyFlagBits {
   switch (loc) {
@@ -274,8 +274,8 @@ auto MemoryPool::allocate(
   }
 
   // If no existing chunk has space then create a new chunk.
-  auto newChunkSize    = size > g_minChunkSize ? size : g_minChunkSize;
-  auto newChunkMemType = getMemoryType(getVkMemoryProperties(location), supportedMemoryTypes);
+  const auto newChunkSize    = size > g_minChunkSize ? size : g_minChunkSize;
+  const auto newChunkMemType = getMemoryType(getVkMemoryProperties(location), supportedMemoryTypes);
   m_chunks.emplace_front(
       m_logger,
       m_vkDevice,

--- a/src/tria/gfx_vulkan/internal/mesh.hpp
+++ b/src/tria/gfx_vulkan/internal/mesh.hpp
@@ -1,8 +1,7 @@
 #pragma once
-#include "device.hpp"
+#include "buffer.hpp"
 #include "tria/asset/mesh.hpp"
 #include "tria/log/api.hpp"
-#include <cstdint>
 #include <vector>
 #include <vulkan/vulkan.h>
 
@@ -18,14 +17,14 @@ public:
   Mesh(log::Logger* logger, Device* device, const asset::Mesh* asset);
   Mesh(const Mesh& rhs) = delete;
   Mesh(Mesh&& rhs)      = delete;
-  ~Mesh();
+  ~Mesh()               = default;
 
   auto operator=(const Mesh& rhs) -> Mesh& = delete;
   auto operator=(Mesh&& rhs) -> Mesh& = delete;
 
   [[nodiscard]] auto getVertexCount() const noexcept { return m_vertexCount; }
 
-  [[nodiscard]] auto getVkVertexBuffer() const noexcept { return m_vkVertexBuffer; }
+  [[nodiscard]] auto getVertexBuffer() const noexcept -> const Buffer& { return m_vertexBuffer; }
 
   [[nodiscard]] auto getVkVertexBindingDescriptions() const noexcept
       -> std::vector<VkVertexInputBindingDescription>;
@@ -34,10 +33,8 @@ public:
       -> std::vector<VkVertexInputAttributeDescription>;
 
 private:
-  const Device* m_device;
   uint32_t m_vertexCount;
-  VkBuffer m_vkVertexBuffer;
-  MemoryBlock m_vertexBufferMemory;
+  Buffer m_vertexBuffer;
 };
 
 } // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/mesh.hpp
+++ b/src/tria/gfx_vulkan/internal/mesh.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "buffer.hpp"
+#include "transferer.hpp"
 #include "tria/asset/mesh.hpp"
 #include "tria/log/api.hpp"
 #include <vector>
@@ -22,7 +23,9 @@ public:
   auto operator=(const Mesh& rhs) -> Mesh& = delete;
   auto operator=(Mesh&& rhs) -> Mesh& = delete;
 
-  [[nodiscard]] auto getVertexCount() const noexcept { return m_vertexCount; }
+  [[nodiscard]] auto getVertexCount() const noexcept { return m_asset->getVertCount(); }
+
+  auto transferData(Transferer* transferer) const noexcept -> void;
 
   [[nodiscard]] auto getVertexBuffer() const noexcept -> const Buffer& { return m_vertexBuffer; }
 
@@ -33,7 +36,8 @@ public:
       -> std::vector<VkVertexInputAttributeDescription>;
 
 private:
-  uint32_t m_vertexCount;
+  const asset::Mesh* m_asset;
+  mutable bool m_buffersUploaded;
   Buffer m_vertexBuffer;
 };
 

--- a/src/tria/gfx_vulkan/internal/renderer.cpp
+++ b/src/tria/gfx_vulkan/internal/renderer.cpp
@@ -147,7 +147,7 @@ auto Renderer::draw(const Graphic* graphic) -> void {
   vkCmdBindPipeline(
       m_gfxVkCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphic->getVkPipeline());
 
-  std::array<VkBuffer, 1> vertexBuffers           = {mesh->getVkVertexBuffer()};
+  std::array<VkBuffer, 1> vertexBuffers           = {mesh->getVertexBuffer().getVkBuffer()};
   std::array<VkDeviceSize, 1> vertexBufferOffsets = {0};
   vkCmdBindVertexBuffers(
       m_gfxVkCommandBuffer,

--- a/src/tria/gfx_vulkan/internal/transferer.cpp
+++ b/src/tria/gfx_vulkan/internal/transferer.cpp
@@ -1,0 +1,67 @@
+#include "transferer.hpp"
+#include "utils.hpp"
+
+namespace tria::gfx::internal {
+
+namespace {
+
+constexpr auto g_minTransferBufferSize = 8 * 1024 * 1024;
+
+} // namespace
+
+auto Transferer::reset() noexcept -> void {
+  m_work.clear();
+
+  // Reset the taken offset on all transfer buffers.
+  for (auto& buffAndOffset : m_transferBuffers) {
+    buffAndOffset.second = 0;
+  }
+}
+
+auto Transferer::queueTransfer(const void* data, size_t size, const Buffer& destination) -> void {
+  assert(size <= destination.getSize());
+  assert(destination.getLocation() == MemoryLocation::Device);
+
+  // Upload the data to a transfer buffer.
+  const auto src = getTransferSpace(size);
+  assert(src.second + size < src.first.getSize());
+  src.first.upload(data, size, src.second);
+
+  // Add a work item to copy the data from the transfer buffer to the destination.
+  m_work.push_back(Work{src, destination, size});
+}
+
+auto Transferer::record(VkCommandBuffer buffer) noexcept -> void {
+  for (const auto& work : m_work) {
+    VkBufferCopy copyRegion = {};
+    copyRegion.srcOffset    = work.src.second;
+    copyRegion.dstOffset    = 0U;
+    copyRegion.size         = work.size;
+    vkCmdCopyBuffer(buffer, work.src.first.getVkBuffer(), work.dst.getVkBuffer(), 1, &copyRegion);
+  }
+  m_work.clear();
+}
+
+auto Transferer::getTransferSpace(size_t size) -> std::pair<Buffer&, uint32_t> {
+  // Find space in an existing transfer buffer.
+  for (auto& [buff, offset] : m_transferBuffers) {
+    // Check if this transfer buffer still has enough space left.
+    if (buff.getSize() - offset >= size) {
+      const auto resultOffset = offset;
+      offset += size;
+      return {buff, resultOffset};
+    }
+  }
+
+  // If no transfer buffers has enough space then create a new one.
+  const auto newBuffSize = size > g_minTransferBufferSize ? size : g_minTransferBufferSize;
+  m_transferBuffers.emplace_back(
+      Buffer{m_device, newBuffSize, MemoryLocation::Host, BufferUsage::Transfer},
+      static_cast<uint32_t>(size));
+
+  LOG_D(m_logger, "Vulkan transfer buffer created", {"size", log::MemSize{newBuffSize}});
+
+  return {m_transferBuffers.back().first, 0U};
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/transferer.hpp
+++ b/src/tria/gfx_vulkan/internal/transferer.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include "buffer.hpp"
+#include "device.hpp"
+#include "tria/log/api.hpp"
+#include <memory>
+#include <utility>
+#include <vector>
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+/* Memory transferer.
+ * Responsible for transfering memory from the cpu side to the gpu side.
+ * Transfers can be 'queued' to the transferer and then batch recorded to a command-buffer.
+ */
+class Transferer final {
+public:
+  Transferer(log::Logger* logger, Device* device) : m_logger{logger}, m_device{device} {}
+  ~Transferer() = default;
+
+  /* Reset the transferer.
+   * This clears any queued work and frees up the used transfer buffers.
+   * Note: Only call this after the device has finished executing the command-buffer containing the
+   * transfer operations.
+   * Usually called at the beginning of a frame.
+   */
+  auto reset() noexcept -> void;
+
+  /* Queue a transfer of the specified cpu memory to the destination buffer.
+   */
+  auto queueTransfer(const void* data, size_t memSize, const Buffer& destination) -> void;
+
+  /* Record transfer commands for the queued work.
+   * Note: clears queued transfer items, so recording can be done in batches. However the required
+   * transfer buffers are only cleared when calling 'reset'.
+   */
+  auto record(VkCommandBuffer buffer) noexcept -> void;
+
+private:
+  struct Work final {
+    std::pair<const Buffer&, uint32_t> src;
+    const Buffer& dst;
+    size_t size;
+
+    Work(std::pair<const Buffer&, uint32_t> src, const Buffer& dst, size_t size) :
+        src{std::move(src)}, dst{dst}, size{size} {}
+  };
+
+  log::Logger* m_logger;
+  Device* m_device;
+  std::vector<std::pair<Buffer, uint32_t>> m_transferBuffers;
+  std::vector<Work> m_work;
+
+  /* Get a buffer (and an offset into that buffer) to use as a transfer buffer.
+   */
+  [[nodiscard]] auto getTransferSpace(size_t size) -> std::pair<Buffer&, uint32_t>;
+};
+
+using TransfererUnique = std::unique_ptr<Transferer>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -85,7 +85,7 @@ NativeCanvas::NativeCanvas(
   m_swapchain = std::make_unique<Swapchain>(logger, m_device.get(), vSync);
 
   for (auto i = 0U; i != m_renderers.size(); ++i) {
-    m_renderers[i] = std::make_unique<Renderer>(m_device.get());
+    m_renderers[i] = std::make_unique<Renderer>(m_logger, m_device.get());
   }
 }
 


### PR DESCRIPTION
Add a utility for transferring memory from the cpu to the gpu. All transferring is done at the beginning of the frame before doing any rendering. This does not use the transfer queue yet but instead just transfers over the graphics queue.

Mesh vertex buffers are now transferred to gpu memory instead of just rendering from a cpu vertex buffer.