### PR TITLE
Fullscreen support

### DIFF
--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -26,6 +26,15 @@ auto runApp(pal::Platform& platform, asset::Database& db, gfx::Context& gfx) {
 
     platform.handleEvents();
 
+    // Toggle fullscreen when pressing '1'.
+    if (win.isKeyPressed(pal::Key::Alpha1)) {
+      if (win.getFullscreenMode() == pal::FullscreenMode::Disable) {
+        win.setSize({0, 0}, pal::FullscreenMode::Enable);
+      } else {
+        win.setSize({512, 512}, pal::FullscreenMode::Disable);
+      }
+    }
+
     pos += math::Vec2f(win.getScrollDelta()) * 0.01f;
 
     if (canvas.drawBegin(math::color::gray())) {

--- a/include/tria/gfx/context.hpp
+++ b/include/tria/gfx/context.hpp
@@ -7,7 +7,10 @@ namespace tria::gfx {
 
 class NativeContext;
 
-enum class VSyncMode { Disable, Enable };
+enum class VSyncMode {
+  Disable,
+  Enable,
+};
 
 /*
  * Abstraction over a graphics context.
@@ -31,5 +34,15 @@ public:
 private:
   std::unique_ptr<NativeContext> m_native;
 };
+
+[[nodiscard]] constexpr auto getName(VSyncMode mode) noexcept -> std::string_view {
+  switch (mode) {
+  case VSyncMode::Enable:
+    return "enable";
+  case VSyncMode::Disable:
+    return "disable";
+  }
+  return "unknown";
+}
 
 } // namespace tria::gfx

--- a/include/tria/pal/platform.hpp
+++ b/include/tria/pal/platform.hpp
@@ -30,7 +30,7 @@ public:
 
   /* Create a new os window.
    */
-  [[nodiscard]] auto createWindow(WindowSize size) -> Window;
+  [[nodiscard]] auto createWindow(WindowSize desiredSize) -> Window;
 
 private:
   std::unique_ptr<NativePlatform> m_native;

--- a/include/tria/pal/window.hpp
+++ b/include/tria/pal/window.hpp
@@ -13,6 +13,11 @@ using WindowSize   = math::Vec<uint16_t, 2>;
 using WindowPos    = math::Vec<int32_t, 2>;
 using WindowPosNrm = math::Vec<float, 2>;
 
+enum class FullscreenMode {
+  Disable,
+  Enable,
+};
+
 /* Handle to a native window.
  * When handle is destroyed the native window is also closed. Supports moving ownership.
  *
@@ -82,8 +87,14 @@ public:
    */
   [[nodiscard]] auto isKeyReleased(Key key) const noexcept -> bool;
 
+  /* Update the title of the window.
+   */
   auto setTitle(std::string_view title) -> void;
-  auto setSize(WindowSize size) -> void;
+
+  /* Update the size of the window.
+   * Returns true if the update was successfully or false if it failed.
+   */
+  auto setSize(WindowSize desiredSize, FullscreenMode fullscreen) -> bool;
 
   [[nodiscard]] auto getNativePlatformPtr() const noexcept { return m_platform; }
   [[nodiscard]] auto getWindowId() const noexcept { return m_id; }
@@ -100,5 +111,15 @@ private:
     assert(m_platform);
   }
 };
+
+[[nodiscard]] constexpr auto getName(FullscreenMode mode) noexcept -> std::string_view {
+  switch (mode) {
+  case FullscreenMode::Enable:
+    return "enable";
+  case FullscreenMode::Disable:
+    return "disable";
+  }
+  return "unknown";
+}
 
 } // namespace tria::pal

--- a/include/tria/pal/window.hpp
+++ b/include/tria/pal/window.hpp
@@ -53,6 +53,10 @@ public:
    */
   [[nodiscard]] auto getSize() const noexcept -> WindowSize;
 
+  /* Get the current fullscreen mode.
+   */
+  [[nodiscard]] auto getFullscreenMode() const noexcept -> FullscreenMode;
+
   /* Has the user requested to close this window.
    */
   [[nodiscard]] auto getIsCloseRequested() const noexcept -> bool;

--- a/src/tria/gfx_vulkan/internal/swapchain.cpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.cpp
@@ -302,6 +302,7 @@ auto Swapchain::initSwapchain(VkRenderPass vkRenderPass) -> bool {
   LOG_D(
       m_logger,
       "Vulkan swapchain created",
+      {"vSync", getName(m_vSync)},
       {"presentMode", getVkPresentModeString(presentMode)},
       {"imageCount", m_imgCount},
       {"size", m_extent.width, m_extent.height});

--- a/src/tria/pal/native_platform.win32.cpp
+++ b/src/tria/pal/native_platform.win32.cpp
@@ -121,8 +121,8 @@ auto NativePlatform::createWindow(WindowSize desiredSize) -> Window {
   if (!GetClientRect(winHandle, &realClientRect)) {
     internal::throwPlatformError();
   }
-  WindowSize realSize = {
-      realClientRect.right - realClientRect.left, realClientRect.bottom - realClientRect.top};
+  WindowSize realSize = {realClientRect.right - realClientRect.left,
+                         realClientRect.bottom - realClientRect.top};
 
   // Get window size of the window (including borders).
   RECT realWinRect;
@@ -244,9 +244,12 @@ auto NativePlatform::setWinSize(WindowId id, WindowSize desiredSize, FullscreenM
   // us a different size then was desired).
   RECT realClientRect;
   if (GetClientRect(winData->handle, &realClientRect)) {
-    winData->size = {
-        realClientRect.right - realClientRect.left, realClientRect.bottom - realClientRect.top};
+    winData->size = {realClientRect.right - realClientRect.left,
+                     realClientRect.bottom - realClientRect.top};
   }
+
+  // Update the fullscreen mode on the window data.
+  winData->fullscreen = fullscreen;
 
   return true;
 }

--- a/src/tria/pal/native_platform.win32.cpp
+++ b/src/tria/pal/native_platform.win32.cpp
@@ -1,6 +1,7 @@
 #include "native_platform.win32.hpp"
 #include "internal/win32_utils.hpp"
 #include "tria/pal/utils.hpp"
+#include "tria/pal/window.hpp"
 #include <array>
 
 namespace tria::pal {
@@ -55,7 +56,7 @@ auto NativePlatform::handleEvents() -> void {
   }
 }
 
-auto NativePlatform::createWindow(WindowSize size) -> Window {
+auto NativePlatform::createWindow(WindowSize desiredSize) -> Window {
   auto winId = m_nextWinId++;
 
   // Create a unique class-name for this window class.
@@ -65,11 +66,11 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
   const auto screenWidth  = GetSystemMetrics(SM_CXSCREEN);
   const auto screenHeight = GetSystemMetrics(SM_CYSCREEN);
 
-  if (size.x() == 0) {
-    size.x() = screenWidth;
+  if (desiredSize.x() == 0) {
+    desiredSize.x() = screenWidth;
   }
-  if (size.y() == 0) {
-    size.y() = screenHeight;
+  if (desiredSize.y() == 0) {
+    desiredSize.y() = screenHeight;
   }
 
   // Create a window-class structure.
@@ -89,13 +90,14 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
     internal::throwPlatformError();
   }
 
-  const DWORD dwStyle = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+  const DWORD dwStyle           = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+  const DWORD dwFullscreenStyle = WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
 
   // Calculate the size of the window (because we give width and height of the content area).
-  RECT winRect   = {};
-  winRect.right  = static_cast<long>(size.x());
-  winRect.bottom = static_cast<long>(size.y());
-  AdjustWindowRect(&winRect, dwStyle, false);
+  RECT desiredWinRect   = {};
+  desiredWinRect.right  = static_cast<long>(desiredSize.x());
+  desiredWinRect.bottom = static_cast<long>(desiredSize.y());
+  AdjustWindowRect(&desiredWinRect, dwStyle, false);
 
   // Create a new window.
   auto winHandle = CreateWindow(
@@ -104,8 +106,8 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
       dwStyle,
       0,
       0,
-      winRect.right - winRect.left,
-      winRect.bottom - winRect.top,
+      desiredWinRect.right - desiredWinRect.left,
+      desiredWinRect.bottom - desiredWinRect.top,
       nullptr,
       nullptr,
       m_hInstance,
@@ -114,9 +116,23 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
     internal::throwPlatformError();
   }
 
+  // Get the content size that the windowmanager gave the window (might not match the desired size).
+  RECT realClientRect;
+  if (!GetClientRect(winHandle, &realClientRect)) {
+    internal::throwPlatformError();
+  }
+  WindowSize realSize = {
+      realClientRect.right - realClientRect.left, realClientRect.bottom - realClientRect.top};
+
+  // Get window size of the window (including borders).
+  RECT realWinRect;
+  if (!GetWindowRect(winHandle, &realWinRect)) {
+    internal::throwPlatformError();
+  }
+
   // Center on screen.
-  const auto x = (screenWidth - winRect.right) / 2;
-  const auto y = (screenHeight - winRect.bottom) / 2;
+  const auto x = (screenWidth - realWinRect.right) / 2;
+  const auto y = (screenHeight - realWinRect.bottom) / 2;
   SetWindowPos(winHandle, nullptr, x, y, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
 
   // Show and focus window.
@@ -124,10 +140,17 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
   SetForegroundWindow(winHandle);
   SetFocus(winHandle);
 
-  LOG_I(m_logger, "Window created", {"id", winId}, {"size", size});
+  LOG_I(
+      m_logger,
+      "Window created",
+      {"id", winId},
+      {"desiredSize", desiredSize},
+      {"realSize", realSize});
 
   // Keep track of the window data.
-  m_windows.insert({winId, WindowData{winId, winHandle, std::move(className), dwStyle, size}});
+  m_windows.insert(
+      {winId,
+       WindowData{winId, winHandle, std::move(className), dwStyle, dwFullscreenStyle, realSize}});
 
   // Return a handle to the window.
   return Window{this, winId};
@@ -158,25 +181,74 @@ auto NativePlatform::setWinTitle(WindowId id, std::string_view title) noexcept -
   SetWindowText(winData->handle, title.data());
 }
 
-auto NativePlatform::setWinSize(WindowId id, const WindowSize size) noexcept -> void {
+auto NativePlatform::setWinSize(WindowId id, WindowSize desiredSize, FullscreenMode fullscreen)
+    -> bool {
+
   auto* winData = getWindow(id);
   assert(winData);
 
-  // Calculate the size of the window (because we give width and height of the content area).
-  RECT winRect   = {};
-  winRect.right  = static_cast<long>(size.x());
-  winRect.bottom = static_cast<long>(size.y());
-  AdjustWindowRect(&winRect, winData->dwStyle, false);
+  if (desiredSize.x() == 0) {
+    desiredSize.x() = GetSystemMetrics(SM_CXSCREEN);
+  }
+  if (desiredSize.y() == 0) {
+    desiredSize.y() = GetSystemMetrics(SM_CYSCREEN);
+  }
 
-  // Set the window size.
-  SetWindowPos(
-      winData->handle,
-      nullptr,
-      0,
-      0,
-      winRect.right - winRect.left,
-      winRect.bottom - winRect.top,
-      SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOZORDER);
+  LOG_D(
+      m_logger,
+      "Updating window size",
+      {"id", id},
+      {"desiredSize", desiredSize},
+      {"fullscreen", getName(fullscreen)});
+
+  switch (fullscreen) {
+  case FullscreenMode::Enable:
+    // TODO(bastian): Investigate supporting different sizes in fullscreen, requires actually
+    // changing the system display settings.
+
+    // Update the window style.
+    SetWindowLongPtr(winData->handle, GWL_STYLE, winData->dwFullscreenStyle);
+
+    // Present the updated window.
+    ShowWindow(winData->handle, SW_MAXIMIZE);
+    break;
+
+  case FullscreenMode::Disable:
+  default:
+
+    // Update the window style.
+    SetWindowLongPtr(winData->handle, GWL_STYLE, winData->dwStyle);
+
+    // Calculate the size of the window (because we give width and height of the content area).
+    RECT winRect   = {};
+    winRect.right  = static_cast<long>(desiredSize.x());
+    winRect.bottom = static_cast<long>(desiredSize.y());
+    AdjustWindowRect(&winRect, winData->dwStyle, false);
+
+    // Set the window size.
+    SetWindowPos(
+        winData->handle,
+        nullptr,
+        0,
+        0,
+        winRect.right - winRect.left,
+        winRect.bottom - winRect.top,
+        SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOZORDER);
+
+    // Present the updated window.
+    ShowWindow(winData->handle, SW_RESTORE);
+    break;
+  }
+
+  // Update the local size with the real content size of the window (in case the window-manager gave
+  // us a different size then was desired).
+  RECT realClientRect;
+  if (GetClientRect(winData->handle, &realClientRect)) {
+    winData->size = {
+        realClientRect.right - realClientRect.left, realClientRect.bottom - realClientRect.top};
+  }
+
+  return true;
 }
 
 auto NativePlatform::win32Setup() -> void {

--- a/src/tria/pal/native_platform.win32.hpp
+++ b/src/tria/pal/native_platform.win32.hpp
@@ -18,15 +18,22 @@ struct WindowData {
   HWND handle;
   std::string className;
   DWORD dwStyle;
+  DWORD dwFullscreenStyle;
   WindowSize size;
   internal::WindowInput input;
 
   WindowData(
-      WindowId id, HWND handle, std::string className, DWORD dwStyle, WindowSize size) noexcept :
+      WindowId id,
+      HWND handle,
+      std::string className,
+      DWORD dwStyle,
+      DWORD dwFullscreenStyle,
+      WindowSize size) noexcept :
       id{id},
       handle{handle},
       className{std::move(className)},
       dwStyle{dwStyle},
+      dwFullscreenStyle{dwFullscreenStyle},
       size{size},
       input{} {}
 };
@@ -60,13 +67,13 @@ public:
 
   auto handleEvents() -> void;
 
-  auto createWindow(WindowSize size) -> Window;
+  auto createWindow(WindowSize desiredSize) -> Window;
 
   auto destroyWindow(WindowId id) noexcept -> void;
 
   auto setWinTitle(WindowId id, std::string_view title) noexcept -> void;
 
-  auto setWinSize(WindowId id, WindowSize size) noexcept -> void;
+  auto setWinSize(WindowId id, WindowSize desiredSize, FullscreenMode fullscreen) -> bool;
 
 private:
   log::Logger* m_logger;

--- a/src/tria/pal/native_platform.win32.hpp
+++ b/src/tria/pal/native_platform.win32.hpp
@@ -20,6 +20,7 @@ struct WindowData {
   DWORD dwStyle;
   DWORD dwFullscreenStyle;
   WindowSize size;
+  FullscreenMode fullscreen;
   internal::WindowInput input;
 
   WindowData(
@@ -35,6 +36,7 @@ struct WindowData {
       dwStyle{dwStyle},
       dwFullscreenStyle{dwFullscreenStyle},
       size{size},
+      fullscreen{FullscreenMode::Disable},
       input{} {}
 };
 
@@ -55,6 +57,12 @@ public:
     auto* win = getWindow(id);
     assert(win);
     return win->size;
+  }
+
+  [[nodiscard]] auto getWinFullscreenMode(WindowId id) const noexcept -> FullscreenMode {
+    auto* win = getWindow(id);
+    assert(win);
+    return win->fullscreen;
   }
 
   [[nodiscard]] auto getWinInput(WindowId id) const noexcept -> const internal::WindowInput& {

--- a/src/tria/pal/native_platform.xcb.cpp
+++ b/src/tria/pal/native_platform.xcb.cpp
@@ -2,7 +2,9 @@
 #include "internal/xcb_utils.hpp"
 #include "tria/pal/err/platform_err.hpp"
 #include "tria/pal/utils.hpp"
+#include "tria/pal/window.hpp"
 #include <array>
+#include <xcb/xproto.h>
 
 namespace tria::pal {
 
@@ -132,7 +134,7 @@ auto NativePlatform::handleEvents() -> void {
   }
 }
 
-auto NativePlatform::createWindow(WindowSize size) -> Window {
+auto NativePlatform::createWindow(WindowSize desiredSize) -> Window {
 
   const auto winId          = xcb_generate_id(m_xcbCon);
   const auto valMask        = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
@@ -145,11 +147,13 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
       evtMask,
   };
 
-  if (size.x() == 0) {
-    size.x() = m_xcbScreen->width_in_pixels;
+  // TODO(bastian): We are using the sizes we got when initializing xcb, we could consider getting
+  // more up to date info. However that might make creating a window slower.
+  if (desiredSize.x() == 0) {
+    desiredSize.x() = m_xcbScreen->width_in_pixels;
   }
-  if (size.y() == 0) {
-    size.y() = m_xcbScreen->height_in_pixels;
+  if (desiredSize.y() == 0) {
+    desiredSize.y() = m_xcbScreen->height_in_pixels;
   }
 
   // Create a window on the xcb side.
@@ -160,8 +164,8 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
       m_xcbScreen->root,
       0,
       0,
-      size.x(),
-      size.y(),
+      desiredSize.x(),
+      desiredSize.y(),
       0,
       XCB_WINDOW_CLASS_INPUT_OUTPUT,
       m_xcbScreen->root_visual,
@@ -176,10 +180,12 @@ auto NativePlatform::createWindow(WindowSize size) -> Window {
   xcb_map_window(m_xcbCon, winId);
   xcb_flush(m_xcbCon);
 
-  LOG_I(m_logger, "Window created", {"id", winId}, {"size", size});
+  LOG_I(m_logger, "Window created", {"id", winId}, {"desiredSize", desiredSize});
 
   // Keep track of the window data.
-  m_windows.insert({winId, WindowData{winId, size}});
+  // DesiredSize might not be 'correct' if the compositor cannot achieve the desired size, however
+  // in the 'configure' event we will update to the 'correct' size.
+  m_windows.insert({winId, WindowData{winId, desiredSize}});
 
   // Return a handle to the window.
   return Window{this, winId};
@@ -214,19 +220,50 @@ auto NativePlatform::setWinTitle(WindowId id, std::string_view title) noexcept -
   xcb_flush(m_xcbCon);
 }
 
-auto NativePlatform::setWinSize(WindowId id, const WindowSize size) noexcept -> void {
+auto NativePlatform::setWinSize(WindowId id, WindowSize desiredSize, FullscreenMode fullscreen)
+    -> bool {
+
+  // TODO(bastian): We are using the sizes we got when initializing xcb, we could consider getting
+  // more up to date info. However that might make the resizing slower.
+  if (desiredSize.x() == 0) {
+    desiredSize.x() = m_xcbScreen->width_in_pixels;
+  }
+  if (desiredSize.y() == 0) {
+    desiredSize.y() = m_xcbScreen->height_in_pixels;
+  }
+
+  LOG_D(
+      m_logger,
+      "Updating window size",
+      {"id", id},
+      {"desiredSize", desiredSize},
+      {"fullscreen", getName(fullscreen)});
+
+  // Update full-screen state.
+  switch (fullscreen) {
+  case FullscreenMode::Enable:
+    // TODO(bastian): Investigate supporting different sizes in fullscreen, requires actually
+    // changing the system display settings.
+    desiredSize.x() = m_xcbScreen->width_in_pixels;
+    desiredSize.y() = m_xcbScreen->height_in_pixels;
+    xcbSetWmState(id, m_xcbWmStateFullscreenAtom, true);
+    break;
+  case FullscreenMode::Disable:
+  default:
+    xcbSetWmState(id, m_xcbWmStateFullscreenAtom, false);
+    break;
+  }
+
   const auto valList = std::array<uint32_t, 2>{
-      size.x(),
-      size.y(),
+      desiredSize.x(),
+      desiredSize.y(),
   };
   xcb_configure_window(
       m_xcbCon, id, XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT, valList.data());
-  xcb_flush(m_xcbCon);
 
-  // Update local information immediately.
-  auto* win = getWindow(id);
-  assert(win);
-  win->size = size;
+  xcb_flush(m_xcbCon);
+  xcbCheckErr();
+  return true;
 }
 
 auto NativePlatform::xcbSetup() -> void {
@@ -243,9 +280,11 @@ auto NativePlatform::xcbSetup() -> void {
   }
   m_xcbScreen = rootItr.data;
 
-  // Retrieve message atoms to listen for.
-  m_xcbProtoMsgAtom  = xcbGetAtom("WM_PROTOCOLS");
-  m_xcbDeleteMsgAtom = xcbGetAtom("WM_DELETE_WINDOW");
+  // Retreive atoms to use while communicating with the x-server.
+  m_xcbProtoMsgAtom          = xcbGetAtom("WM_PROTOCOLS");
+  m_xcbDeleteMsgAtom         = xcbGetAtom("WM_DELETE_WINDOW");
+  m_xcbWmStateAtom           = xcbGetAtom("_NET_WM_STATE");
+  m_xcbWmStateFullscreenAtom = xcbGetAtom("_NET_WM_STATE_FULLSCREEN");
 
   LOG_I(
       m_logger,
@@ -303,9 +342,27 @@ auto NativePlatform::xcbCheckErr() -> void {
   }
 }
 
-auto NativePlatform::xcbGetAtom(const std::string& name) noexcept -> xcb_atom_t {
+auto NativePlatform::xcbGetAtom(const std::string& name) const noexcept -> xcb_atom_t {
   auto atomReply = XCB_CALL_WITH_REPLY(m_xcbCon, xcb_intern_atom, 0, name.length(), name.data());
   return atomReply.getValue()->atom;
+}
+
+auto NativePlatform::xcbSetWmState(WindowId window, xcb_atom_t stateAtom, bool set) const noexcept
+    -> void {
+  xcb_client_message_event_t evt = {};
+  evt.response_type              = XCB_CLIENT_MESSAGE;
+  evt.format                     = 32;
+  evt.window                     = window;
+  evt.type                       = m_xcbWmStateAtom;
+  evt.data.data32[0]             = set ? 1 : 0;
+  evt.data.data32[1]             = stateAtom;
+
+  xcb_send_event(
+      m_xcbCon,
+      false,
+      m_xcbScreen->root,
+      XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT,
+      reinterpret_cast<const char*>(&evt));
 }
 
 auto NativePlatform::resetEvents() noexcept -> void {

--- a/src/tria/pal/native_platform.xcb.hpp
+++ b/src/tria/pal/native_platform.xcb.hpp
@@ -39,13 +39,13 @@ public:
 
   auto handleEvents() -> void;
 
-  auto createWindow(WindowSize size) -> Window;
+  auto createWindow(WindowSize desiredSize) -> Window;
 
   auto destroyWindow(WindowId id) noexcept -> void;
 
   auto setWinTitle(WindowId id, std::string_view title) noexcept -> void;
 
-  auto setWinSize(WindowId id, WindowSize size) noexcept -> void;
+  auto setWinSize(WindowId id, WindowSize desiredSize, FullscreenMode mode) -> bool;
 
 private:
   log::Logger* m_logger;
@@ -53,6 +53,8 @@ private:
   xcb_screen_t* m_xcbScreen;
   xcb_atom_t m_xcbProtoMsgAtom;
   xcb_atom_t m_xcbDeleteMsgAtom;
+  xcb_atom_t m_xcbWmStateAtom;
+  xcb_atom_t m_xcbWmStateFullscreenAtom;
   std::unordered_map<WindowId, WindowData> m_windows;
 
   auto xcbSetup() -> void;
@@ -61,7 +63,8 @@ private:
   auto xcbTeardown() noexcept -> void;
   auto xcbCheckErr() -> void;
 
-  auto xcbGetAtom(const std::string& name) noexcept -> xcb_atom_t;
+  auto xcbGetAtom(const std::string& name) const noexcept -> xcb_atom_t;
+  auto xcbSetWmState(WindowId window, xcb_atom_t stateAtom, bool set) const noexcept -> void;
 
   /* Reset any events (like pressed keys) from the previous 'handleEvents' call.
    */

--- a/src/tria/pal/native_platform.xcb.hpp
+++ b/src/tria/pal/native_platform.xcb.hpp
@@ -55,6 +55,7 @@ private:
   xcb_atom_t m_xcbDeleteMsgAtom;
   xcb_atom_t m_xcbWmStateAtom;
   xcb_atom_t m_xcbWmStateFullscreenAtom;
+  xcb_atom_t m_xcbWmStateBypassCompositorAtom;
   std::unordered_map<WindowId, WindowData> m_windows;
 
   auto xcbSetup() -> void;
@@ -65,6 +66,7 @@ private:
 
   auto xcbGetAtom(const std::string& name) const noexcept -> xcb_atom_t;
   auto xcbSetWmState(WindowId window, xcb_atom_t stateAtom, bool set) const noexcept -> void;
+  auto xcbSetBypassCompositor(WindowId window, bool set) const noexcept -> void;
 
   /* Reset any events (like pressed keys) from the previous 'handleEvents' call.
    */

--- a/src/tria/pal/native_platform.xcb.hpp
+++ b/src/tria/pal/native_platform.xcb.hpp
@@ -13,9 +13,11 @@ using WindowId = uint32_t;
 struct WindowData {
   WindowId id;
   WindowSize size;
+  FullscreenMode fullscreen;
   internal::WindowInput input;
 
-  WindowData(WindowId id, WindowSize size) noexcept : id{id}, size{size}, input{} {}
+  WindowData(WindowId id, WindowSize size) noexcept :
+      id{id}, size{size}, fullscreen{FullscreenMode::Disable}, input{} {}
 };
 
 class NativePlatform final {
@@ -29,6 +31,12 @@ public:
     auto* win = getWindow(id);
     assert(win);
     return win->size;
+  }
+
+  [[nodiscard]] auto getWinFullscreenMode(WindowId id) const noexcept -> FullscreenMode {
+    auto* win = getWindow(id);
+    assert(win);
+    return win->fullscreen;
   }
 
   [[nodiscard]] auto getWinInput(WindowId id) const noexcept -> const internal::WindowInput& {

--- a/src/tria/pal/window.win32.cpp
+++ b/src/tria/pal/window.win32.cpp
@@ -15,6 +15,11 @@ auto Window::getSize() const noexcept -> WindowSize {
   return m_platform->getWinSize(m_id);
 }
 
+auto Window::getFullscreenMode() const noexcept -> FullscreenMode {
+  assert(m_alive);
+  return m_platform->getWinFullscreenMode(m_id);
+}
+
 auto Window::getIsCloseRequested() const noexcept -> bool {
   assert(m_alive);
   return m_platform->getWinInput(m_id).getIsCloseRequested();

--- a/src/tria/pal/window.win32.cpp
+++ b/src/tria/pal/window.win32.cpp
@@ -49,9 +49,9 @@ auto Window::setTitle(std::string_view title) -> void {
   m_platform->setWinTitle(m_id, title);
 }
 
-auto Window::setSize(const WindowSize size) -> void {
+auto Window::setSize(WindowSize desiredSize, FullscreenMode fullscreen) -> bool {
   assert(m_alive);
-  m_platform->setWinSize(m_id, size);
+  return m_platform->setWinSize(m_id, desiredSize, fullscreen);
 }
 
 } // namespace tria::pal

--- a/src/tria/pal/window.xcb.cpp
+++ b/src/tria/pal/window.xcb.cpp
@@ -15,6 +15,11 @@ auto Window::getSize() const noexcept -> WindowSize {
   return m_platform->getWinSize(m_id);
 }
 
+auto Window::getFullscreenMode() const noexcept -> FullscreenMode {
+  assert(m_alive);
+  return m_platform->getWinFullscreenMode(m_id);
+}
+
 auto Window::getIsCloseRequested() const noexcept -> bool {
   assert(m_alive);
   return m_platform->getWinInput(m_id).getIsCloseRequested();

--- a/src/tria/pal/window.xcb.cpp
+++ b/src/tria/pal/window.xcb.cpp
@@ -50,9 +50,9 @@ auto Window::setTitle(std::string_view title) -> void {
   m_platform->setWinTitle(m_id, title);
 }
 
-auto Window::setSize(WindowSize size) -> void {
+auto Window::setSize(WindowSize desiredSize, FullscreenMode fullscreen) -> bool {
   assert(m_alive);
-  m_platform->setWinSize(m_id, size);
+  return m_platform->setWinSize(m_id, desiredSize, fullscreen);
 }
 
 } // namespace tria::pal


### PR DESCRIPTION
Add support for entering full-screen.

New apis:
```c++
enum class FullscreenMode {
  Disable,
  Enable,
};

// On Window:

auto getFullscreenMode() -> FullscreenMode;

auto setSize(WindowSize desiredSize, FullscreenMode fullscreen) -> bool;
```

Example of toggling fullscreen:
```c++
if (window.getFullscreenMode() == pal::FullscreenMode::Disable) {
  window.setSize({0, 0}, pal::FullscreenMode::Enable);
} else {
  window.setSize({512, 512}, pal::FullscreenMode::Disable);
}
```
Note: At the moment it doesn't support changing desktop resolution, so when entering fullscreen the `size` argument is ignored. The api is like this however to support possibly changing fullscreen desktop resolution in the future.

