### PR TITLE
Add debug names to Vulkan objects

### DIFF
--- a/src/tria/gfx_vulkan/internal/debug_utils.hpp
+++ b/src/tria/gfx_vulkan/internal/debug_utils.hpp
@@ -1,0 +1,188 @@
+#pragma once
+#include <string>
+
+/* Debug utilities.
+ * Turn into no-ops when compiling in non-debug mode.
+ */
+
+#if defined(NDEBUG)
+#define DBG_PHYSDEVICE_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_PHYSDEVICE_NAME(DEVICE, OBJ, NAME)                                                     \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_PHYSICAL_DEVICE,                                                              \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_physicaldevice"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_DEVICE_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_DEVICE_NAME(DEVICE, OBJ, NAME)                                                         \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_DEVICE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_device"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_IMG_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_IMG_NAME(DEVICE, OBJ, NAME)                                                            \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_IMAGE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_img"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_IMGVIEW_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_IMGVIEW_NAME(DEVICE, OBJ, NAME)                                                        \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_IMAGE_VIEW, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_imgview"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_SAMPLER_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_SAMPLER_NAME(DEVICE, OBJ, NAME)                                                        \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_SAMPLER, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_sampler"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_SHADER_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_SHADER_NAME(DEVICE, OBJ, NAME)                                                         \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_SHADER_MODULE,                                                                \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_shader"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_DESCPOOL_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_DESCPOOL_NAME(DEVICE, OBJ, NAME)                                                       \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_DESCRIPTOR_POOL,                                                              \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_descpool"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_DESCLAYOUT_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_DESCLAYOUT_NAME(DEVICE, OBJ, NAME)                                                     \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT,                                                        \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_desclayout"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_DESCSET_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_DESCSET_NAME(DEVICE, OBJ, NAME)                                                        \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_DESCRIPTOR_SET,                                                               \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_descset"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_SWAPCHAIN_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_SWAPCHAIN_NAME(DEVICE, OBJ, NAME)                                                      \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_SWAPCHAIN_KHR,                                                                \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_swapchain"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_FRAMEBUFFER_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_FRAMEBUFFER_NAME(DEVICE, OBJ, NAME)                                                    \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_FRAMEBUFFER,                                                                  \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_framebuffer"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_BUFFER_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_BUFFER_NAME(DEVICE, OBJ, NAME)                                                         \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_BUFFER, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_buffer"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_MEM_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_MEM_NAME(DEVICE, OBJ, NAME)                                                            \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_DEVICE_MEMORY,                                                                \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_memory"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_PIPELINE_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_PIPELINE_NAME(DEVICE, OBJ, NAME)                                                       \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_PIPELINE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_pipeline"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_PIPELINELAYOUT_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_PIPELINELAYOUT_NAME(DEVICE, OBJ, NAME)                                                 \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_PIPELINE_LAYOUT,                                                              \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_pipelinelayout"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_QUEUE_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_QUEUE_NAME(DEVICE, OBJ, NAME)                                                          \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_QUEUE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_queue"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_COMMANDPOOL_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_COMMANDPOOL_NAME(DEVICE, OBJ, NAME)                                                    \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_COMMAND_POOL,                                                                 \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_commandpool"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_COMMANDBUFFER_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_COMMANDBUFFER_NAME(DEVICE, OBJ, NAME)                                                  \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_COMMAND_BUFFER,                                                               \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_commandbuffer"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_SEMPAHORE_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_SEMPAHORE_NAME(DEVICE, OBJ, NAME)                                                      \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_SEMAPHORE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_semaphore"))
+#endif
+
+#if defined(NDEBUG)
+#define DBG_FENCE_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_FENCE_NAME(DEVICE, OBJ, NAME)                                                          \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_FENCE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_fence"))
+#endif

--- a/src/tria/gfx_vulkan/internal/descriptor_manager.hpp
+++ b/src/tria/gfx_vulkan/internal/descriptor_manager.hpp
@@ -10,6 +10,7 @@ namespace tria::gfx::internal {
 // TODO(bastian): Needs testing to what number of sets per VkDescriptorPool makes sense.
 constexpr auto g_descriptorSetsPerGroup = 6;
 
+class Device;
 class Image;
 class ImageSampler;
 class Buffer;
@@ -113,7 +114,7 @@ private:
 class DescriptorGroup final {
 public:
   DescriptorGroup() = delete;
-  DescriptorGroup(log::Logger* logger, VkDevice vkDevice, DescriptorInfo info);
+  DescriptorGroup(log::Logger* logger, const Device* device, DescriptorInfo info, uint32_t groupId);
   DescriptorGroup(const DescriptorGroup& rhs) = delete;
   DescriptorGroup(DescriptorGroup&& rhs)      = delete;
   ~DescriptorGroup();
@@ -157,8 +158,9 @@ public:
 
 private:
   tria::log::Logger* m_logger;
-  VkDevice m_vkDevice;
+  const Device* m_device;
   DescriptorInfo m_info;
+  uint32_t m_groupId;
   VkDescriptorPool m_vkPool;
   VkDescriptorSetLayout m_vkLayout;
   std::array<VkDescriptorSet, g_descriptorSetsPerGroup> m_sets;
@@ -170,8 +172,8 @@ private:
  */
 class DescriptorManager final {
 public:
-  DescriptorManager(log::Logger* logger, VkDevice vkDevice) :
-      m_logger{logger}, m_vkDevice{vkDevice} {}
+  DescriptorManager(log::Logger* logger, const Device* device) :
+      m_logger{logger}, m_device{device}, m_groupIdCounter{0U} {}
   DescriptorManager(const DescriptorManager& rhs)     = delete;
   DescriptorManager(DescriptorManager&& rhs) noexcept = delete;
   ~DescriptorManager()                                = default;
@@ -189,7 +191,8 @@ public:
 
 private:
   log::Logger* m_logger;
-  VkDevice m_vkDevice;
+  const Device* m_device;
+  uint32_t m_groupIdCounter;
   std::forward_list<DescriptorGroup> m_groups;
 };
 

--- a/src/tria/gfx_vulkan/internal/device.hpp
+++ b/src/tria/gfx_vulkan/internal/device.hpp
@@ -7,7 +7,11 @@
 #include <vector>
 #include <vulkan/vulkan.h>
 
-namespace tria::gfx::internal {
+namespace tria::gfx {
+
+class NativeContext;
+
+namespace internal {
 
 /* Abstraction of a graphics device and a surface (window) to render to.
  * Reason why the device is combined with the surface is that you might want / need different device
@@ -22,7 +26,7 @@ class Device final {
 public:
   Device(
       log::Logger* logger,
-      VkInstance vkInstance,
+      const NativeContext* context,
       VkPhysicalDevice vkPhysicalDevice,
       const pal::Window* window);
   Device(const Device& rhs)     = delete;
@@ -39,6 +43,9 @@ public:
   [[nodiscard]] auto getLimits() const noexcept -> const VkPhysicalDeviceLimits& {
     return m_properties.limits;
   }
+  [[nodiscard]] auto getMemProperties() const noexcept -> const VkPhysicalDeviceMemoryProperties& {
+    return m_memProperties;
+  }
 
   [[nodiscard]] auto getVkGraphicsQueue() const noexcept { return m_graphicsQueue; }
   [[nodiscard]] auto getVkGraphicsQueueIdx() const noexcept { return m_graphicsQueueIdx; }
@@ -53,9 +60,12 @@ public:
 
   [[nodiscard]] auto queryVkSurfaceCapabilities() const -> VkSurfaceCapabilitiesKHR;
 
+  auto setDebugName(VkObjectType vkType, uint64_t vkHandle, std::string_view name) const noexcept
+      -> void;
+
 private:
   log::Logger* m_logger;
-  VkInstance m_vkInstance;
+  const NativeContext* m_context;
   VkPhysicalDevice m_vkPhysicalDevice;
   VkPhysicalDeviceProperties m_properties;
   VkPhysicalDeviceFeatures m_features;
@@ -81,7 +91,10 @@ using DeviceUnique = std::unique_ptr<Device>;
 /* Construct a device that is capable of rendering to the given window.
  * Note: returns null if no suitable device is found.
  */
-[[nodiscard]] auto getDevice(log::Logger* logger, VkInstance vkInstance, const pal::Window* window)
+[[nodiscard]] auto
+getDevice(log::Logger* logger, const NativeContext* context, const pal::Window* window)
     -> DeviceUnique;
 
-} // namespace tria::gfx::internal
+} // namespace internal
+
+} // namespace tria::gfx

--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -1,4 +1,5 @@
 #include "graphic.hpp"
+#include "debug_utils.hpp"
 #include "device.hpp"
 #include "mesh.hpp"
 #include "shader.hpp"
@@ -160,6 +161,8 @@ Graphic::Graphic(
   for (auto itr = m_asset->getTextureBegin(); itr != m_asset->getTextureEnd(); ++itr) {
     const auto* tex = textures->get(*itr);
     auto sampler    = ImageSampler{device};
+    DBG_SAMPLER_NAME(m_device, sampler.getVkSampler(), m_asset->getId());
+
     m_descSet.bindImage(dstBinding++, tex->getImage(), sampler);
     m_textures.emplace_back(tex, std::move(sampler));
   }
@@ -196,6 +199,9 @@ auto Graphic::prepareResources(
         m_vertShader,
         m_fragShader,
         m_mesh);
+
+    DBG_PIPELINELAYOUT_NAME(m_device, m_vkPipelineLayout, m_asset->getId());
+    DBG_PIPELINE_NAME(m_device, m_vkPipeline, m_asset->getId());
 
     LOG_D(
         m_logger,

--- a/src/tria/gfx_vulkan/internal/mesh.cpp
+++ b/src/tria/gfx_vulkan/internal/mesh.cpp
@@ -1,4 +1,5 @@
 #include "mesh.hpp"
+#include "debug_utils.hpp"
 #include "utils.hpp"
 #include <cassert>
 
@@ -14,11 +15,11 @@ Mesh::Mesh(log::Logger* logger, Device* device, const asset::Mesh* asset) :
   m_indexDataSize   = sizeof(IndexType) * m_asset->getIndexCount();
   m_indexDataOffset = m_vertexDataSize + padToAlignment(m_vertexDataSize, sizeof(IndexType));
 
-  m_buffer = Buffer{
-      device,
-      m_indexDataOffset + m_indexDataSize,
-      MemoryLocation::Device,
-      BufferUsage::DeviceVertexAndIndexData};
+  m_buffer = Buffer{device,
+                    m_indexDataOffset + m_indexDataSize,
+                    MemoryLocation::Device,
+                    BufferUsage::DeviceVertexAndIndexData};
+  DBG_BUFFER_NAME(device, m_buffer.getVkBuffer(), asset->getId());
 
   LOG_D(
       logger,

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -19,7 +19,7 @@ class Device;
  */
 class Renderer final {
 public:
-  Renderer(log::Logger* logger, Device* device, const VkPhysicalDeviceLimits& deviceLimits);
+  Renderer(log::Logger* logger, Device* device);
   Renderer(const Renderer& rhs)     = delete;
   Renderer(Renderer&& rhs) noexcept = delete;
   ~Renderer();

--- a/src/tria/gfx_vulkan/internal/shader.cpp
+++ b/src/tria/gfx_vulkan/internal/shader.cpp
@@ -1,4 +1,5 @@
 #include "shader.hpp"
+#include "debug_utils.hpp"
 #include "device.hpp"
 #include "utils.hpp"
 #include <cassert>
@@ -25,6 +26,7 @@ Shader::Shader(log::Logger* logger, const Device* device, const asset::Shader* a
   assert(asset);
 
   m_vkModule = createShaderModule(m_device->getVkDevice(), *asset);
+  DBG_SHADER_NAME(m_device, m_vkModule, asset->getId());
 
   LOG_D(m_logger, "Vulkan shader module created", {"asset", asset->getId()});
 }

--- a/src/tria/gfx_vulkan/internal/swapchain.cpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.cpp
@@ -1,4 +1,5 @@
 #include "swapchain.hpp"
+#include "debug_utils.hpp"
 #include "device.hpp"
 #include "utils.hpp"
 #include <array>
@@ -288,15 +289,26 @@ auto Swapchain::initSwapchain(VkRenderPass vkRenderPass) -> bool {
       createVkSwapchain(m_device, m_vkSwapchain, m_imgCount, m_extent, transform, presentMode);
   m_vkImages = getSwapchainVkImages(m_device->getVkDevice(), m_vkSwapchain);
 
+  DBG_SWAPCHAIN_NAME(m_device, m_vkSwapchain, "swapchain");
+
   // Create an imageview for every swapchain image.
-  for (const auto& vkImage : m_vkImages) {
-    m_vkImageViews.push_back(createSurfaceImageView(m_device, vkImage));
+  for (auto i = 0U; i != m_vkImages.size(); ++i) {
+    auto imgView = createSurfaceImageView(m_device, m_vkImages[i]);
+
+    DBG_IMG_NAME(m_device, m_vkImages[i], "swapchain_" + std::to_string(i));
+    DBG_IMGVIEW_NAME(m_device, imgView, "swapchain_" + std::to_string(i));
+
+    m_vkImageViews.push_back(imgView);
   }
 
   // Create a framebuffer for every swapchain image-view.
-  for (const auto& vkImageView : m_vkImageViews) {
-    m_vkFramebuffers.push_back(
-        createSurfaceFramebuffer(m_device, vkRenderPass, vkImageView, m_extent));
+  for (auto i = 0U; i != m_vkImages.size(); ++i) {
+    auto frameBuffer =
+        createSurfaceFramebuffer(m_device, vkRenderPass, m_vkImageViews[i], m_extent);
+
+    DBG_FRAMEBUFFER_NAME(m_device, frameBuffer, "swapchain_" + std::to_string(i));
+
+    m_vkFramebuffers.push_back(frameBuffer);
   }
 
   LOG_D(

--- a/src/tria/gfx_vulkan/internal/texture.cpp
+++ b/src/tria/gfx_vulkan/internal/texture.cpp
@@ -1,4 +1,5 @@
 #include "texture.hpp"
+#include "debug_utils.hpp"
 #include "utils.hpp"
 #include <cassert>
 
@@ -14,6 +15,9 @@ Texture::Texture(log::Logger* logger, Device* device, const asset::Texture* asse
   assert(getVkFormatSize(vkFormat) == sizeof(asset::Pixel));
   assert(getVkFormatChannelCount(vkFormat) == 4U);
   m_image = Image{device, m_asset->getSize(), vkFormat};
+
+  DBG_IMG_NAME(device, m_image.getVkImage(), asset->getId());
+  DBG_IMGVIEW_NAME(device, m_image.getVkImageView(), asset->getId());
 
   LOG_D(
       logger,

--- a/src/tria/gfx_vulkan/internal/transferer.hpp
+++ b/src/tria/gfx_vulkan/internal/transferer.hpp
@@ -17,8 +17,7 @@ namespace tria::gfx::internal {
  */
 class Transferer final {
 public:
-  Transferer(log::Logger* logger, Device* device, const VkPhysicalDeviceLimits& deviceLimits) :
-      m_logger{logger}, m_device{device}, m_deviceLimits{deviceLimits} {}
+  Transferer(log::Logger* logger, Device* device) : m_logger{logger}, m_device{device} {}
   Transferer(const Transferer& rhs)     = delete;
   Transferer(Transferer&& rhs) noexcept = delete;
   ~Transferer()                         = default;
@@ -70,7 +69,6 @@ private:
 
   log::Logger* m_logger;
   Device* m_device;
-  const VkPhysicalDeviceLimits& m_deviceLimits;
   std::forward_list<std::pair<Buffer, uint32_t>> m_transferBuffers;
   std::vector<BufferWork> m_bufferWork;
   std::vector<ImageWork> m_imageWork;

--- a/src/tria/gfx_vulkan/internal/uniform_container.cpp
+++ b/src/tria/gfx_vulkan/internal/uniform_container.cpp
@@ -1,4 +1,5 @@
 #include "uniform_container.hpp"
+#include "debug_utils.hpp"
 #include "tria/gfx/err/gfx_err.hpp"
 #include "utils.hpp"
 #include <cassert>
@@ -60,6 +61,9 @@ auto UniformContainer::upload(const void* data, size_t size)
   auto descSet = m_device->getDescManager().allocate(m_descInfo);
   auto buffer =
       Buffer{m_device, g_uniformBufferSize, MemoryLocation::Host, BufferUsage::HostUniformData};
+
+  DBG_BUFFER_NAME(m_device, buffer.getVkBuffer(), "uniform_container");
+
   descSet.bindUniformBufferDynamic(0U, buffer, g_maxUniformDataSize);
   m_sets.emplace_back(std::move(descSet), std::move(buffer), paddedSize);
 

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -74,7 +74,7 @@ NativeCanvas::NativeCanvas(
   assert(m_context);
   assert(m_window);
 
-  m_device = getDevice(m_logger, m_context->getVkInstance(), window);
+  m_device = getDevice(m_logger, m_context, window);
   if (!m_device) {
     throw err::GfxErr{"No device found with vulkan support"};
   }
@@ -89,7 +89,7 @@ NativeCanvas::NativeCanvas(
   m_swapchain = std::make_unique<Swapchain>(logger, m_device.get(), vSync);
 
   for (auto i = 0U; i != m_renderers.size(); ++i) {
-    m_renderers[i] = std::make_unique<Renderer>(m_logger, m_device.get(), m_device->getLimits());
+    m_renderers[i] = std::make_unique<Renderer>(m_logger, m_device.get());
   }
 }
 

--- a/src/tria/gfx_vulkan/native_context.hpp
+++ b/src/tria/gfx_vulkan/native_context.hpp
@@ -27,6 +27,10 @@ public:
   [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync)
       -> std::unique_ptr<NativeCanvas>;
 
+  auto setDebugName(
+      VkDevice vkDevice, VkObjectType vkType, uint64_t vkHandle, std::string_view name) const
+      noexcept -> void;
+
 private:
   log::Logger* m_logger;
   std::string m_appName;


### PR DESCRIPTION
If the `VK_EXT_debug_utils` extension is present (and the program is compiled in `debug` mode) then add names to Vulkan objects.

Allows for easier debugging with tools like RenderDoc and make messages from the Vulkan validator layer easier to understand.

 For example textures names in RenderDoc:
![image](https://user-images.githubusercontent.com/14230060/89099004-ee32a980-d3f4-11ea-8027-c23376222053.png)
