### PR TITLE
Texture filter mode

### DIFF
--- a/data/quad.gfx
+++ b/data/quad.gfx
@@ -2,5 +2,10 @@
   "vertShader": "shaders/plain.vert.spv",
   "fragShader": "shaders/plain.frag.spv",
   "mesh": "models/quad.obj",
-  "textures": [ "textures/checker.ppm" ]
+  "samplers": [
+    {
+      "texture": "textures/checker.ppm",
+      "filter": "nearest"
+    }
+  ]
 }

--- a/data/triangle.gfx
+++ b/data/triangle.gfx
@@ -2,5 +2,10 @@
   "vertShader": "shaders/plain.vert.spv",
   "fragShader": "shaders/plain.frag.spv",
   "mesh": "models/triangle.obj",
-  "textures": [ "textures/checker.ppm" ]
+  "samplers": [
+    {
+      "texture": "textures/checker.ppm",
+      "filter": "nearest"
+    }
+  ]
 }

--- a/include/tria/asset/graphic.hpp
+++ b/include/tria/asset/graphic.hpp
@@ -8,6 +8,30 @@
 namespace tria::asset {
 
 /*
+ * Contains a reference to a texture and sample settings.
+ */
+class TextureSampler final {
+public:
+  enum class FilterMode : uint8_t {
+    Nearest = 0,
+    Linear  = 1,
+  };
+
+  TextureSampler() = delete;
+  TextureSampler(const Texture* texture, FilterMode filterMode) :
+      m_texture{texture}, m_filterMode{filterMode} {
+    assert(texture);
+  }
+
+  [[nodiscard]] auto getTexture() const noexcept { return m_texture; }
+  [[nodiscard]] auto getFilterMode() const noexcept { return m_filterMode; }
+
+private:
+  const Texture* m_texture;
+  FilterMode m_filterMode;
+};
+
+/*
  * Asset containing data needed for a drawing graphic.
  */
 class Graphic final : public Asset {
@@ -17,12 +41,12 @@ public:
       const Shader* vertShader,
       const Shader* fragShader,
       const Mesh* mesh,
-      std::vector<const Texture*> textures) :
+      std::vector<TextureSampler> samplers) :
       Asset{std::move(id), getKind()},
       m_vertShader{vertShader},
       m_fragShader{fragShader},
       m_mesh{mesh},
-      m_textures{std::move(textures)} {
+      m_samplers{std::move(samplers)} {
     assert(m_vertShader);
     assert(m_fragShader);
     assert(m_mesh);
@@ -40,19 +64,19 @@ public:
   [[nodiscard]] auto getFragShader() const noexcept { return m_fragShader; }
   [[nodiscard]] auto getMesh() const noexcept { return m_mesh; }
 
-  [[nodiscard]] auto getTextureCount() const noexcept { return m_textures.size(); }
-  [[nodiscard]] auto getTextureBegin() const noexcept -> const Texture* const* {
-    return m_textures.data();
+  [[nodiscard]] auto getSamplerCount() const noexcept { return m_samplers.size(); }
+  [[nodiscard]] auto getSamplerBegin() const noexcept -> const TextureSampler* {
+    return m_samplers.data();
   }
-  [[nodiscard]] auto getTextureEnd() const noexcept -> const Texture* const* {
-    return m_textures.data() + m_textures.size();
+  [[nodiscard]] auto getSamplerEnd() const noexcept -> const TextureSampler* {
+    return m_samplers.data() + m_samplers.size();
   }
 
 private:
   const Shader* m_vertShader;
   const Shader* m_fragShader;
   const Mesh* m_mesh;
-  std::vector<const Texture*> m_textures;
+  std::vector<TextureSampler> m_samplers;
 };
 
 } // namespace tria::asset

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,10 +27,10 @@ add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/device.cpp
   tria/gfx_vulkan/internal/graphic.cpp
   tria/gfx_vulkan/internal/image.cpp
-  tria/gfx_vulkan/internal/image_sampler.cpp
   tria/gfx_vulkan/internal/memory_pool.cpp
   tria/gfx_vulkan/internal/mesh.cpp
   tria/gfx_vulkan/internal/renderer.cpp
+  tria/gfx_vulkan/internal/sampler.cpp
   tria/gfx_vulkan/internal/shader.cpp
   tria/gfx_vulkan/internal/swapchain.cpp
   tria/gfx_vulkan/internal/texture.cpp

--- a/src/tria/gfx_vulkan/internal/descriptor_manager.cpp
+++ b/src/tria/gfx_vulkan/internal/descriptor_manager.cpp
@@ -2,7 +2,7 @@
 #include "buffer.hpp"
 #include "debug_utils.hpp"
 #include "image.hpp"
-#include "image_sampler.hpp"
+#include "sampler.hpp"
 #include "tria/math/utils.hpp"
 #include "utils.hpp"
 #include "vulkan/vulkan_core.h"
@@ -140,8 +140,7 @@ auto DescriptorSet::getVkDescSet() const noexcept -> VkDescriptorSet {
   return m_group ? m_group->getVkDescSet(m_id) : nullptr;
 }
 
-auto DescriptorSet::bindImage(uint32_t binding, const Image& img, const ImageSampler& sampler)
-    -> void {
+auto DescriptorSet::bindImage(uint32_t binding, const Image& img, const Sampler& sampler) -> void {
   m_group->bindImage(this, binding, img, sampler);
 }
 
@@ -213,7 +212,7 @@ auto DescriptorGroup::allocate() noexcept -> std::optional<DescriptorSet> {
 }
 
 auto DescriptorGroup::bindImage(
-    DescriptorSet* set, uint32_t binding, const Image& img, const ImageSampler& sampler) -> void {
+    DescriptorSet* set, uint32_t binding, const Image& img, const Sampler& sampler) -> void {
   assert(set);
   assert(set->m_group == this);
   assert(set->m_id >= 0);

--- a/src/tria/gfx_vulkan/internal/descriptor_manager.hpp
+++ b/src/tria/gfx_vulkan/internal/descriptor_manager.hpp
@@ -12,7 +12,7 @@ constexpr auto g_descriptorSetsPerGroup = 6;
 
 class Device;
 class Image;
-class ImageSampler;
+class Sampler;
 class Buffer;
 class DescriptorGroup;
 
@@ -97,7 +97,7 @@ public:
   [[nodiscard]] auto getVkLayout() const noexcept -> VkDescriptorSetLayout;
   [[nodiscard]] auto getVkDescSet() const noexcept -> VkDescriptorSet;
 
-  auto bindImage(uint32_t binding, const Image& img, const ImageSampler& sampler) -> void;
+  auto bindImage(uint32_t binding, const Image& img, const Sampler& sampler) -> void;
   auto bindUniformBuffer(uint32_t binding, const Buffer& buffer) -> void;
   auto bindUniformBufferDynamic(uint32_t binding, const Buffer& buffer, uint32_t maxSize) -> void;
 
@@ -138,8 +138,7 @@ public:
 
   /* Bind an image to an allocated DescriptorSet.
    */
-  auto
-  bindImage(DescriptorSet* set, uint32_t binding, const Image& img, const ImageSampler& sampler)
+  auto bindImage(DescriptorSet* set, uint32_t binding, const Image& img, const Sampler& sampler)
       -> void;
 
   /* Bind a uniform-buffer to an allocated DescriptorSet.

--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -153,14 +153,17 @@ Graphic::Graphic(
 
   // Create a descriptor for the per graphic resources.
   m_descSet = device->getDescManager().allocate(
-      DescriptorInfo{static_cast<uint32_t>(asset->getTextureCount()), 0U, 0U});
+      DescriptorInfo{static_cast<uint32_t>(asset->getSamplerCount()), 0U, 0U});
 
   // Create the texture resources and bind them to our descriptor.
-  m_textures.reserve(m_asset->getTextureCount());
+  m_textures.reserve(m_asset->getSamplerCount());
   auto dstBinding = 0U;
-  for (auto itr = m_asset->getTextureBegin(); itr != m_asset->getTextureEnd(); ++itr) {
-    const auto* tex = textures->get(*itr);
-    auto sampler    = ImageSampler{device};
+  for (auto itr = m_asset->getSamplerBegin(); itr != m_asset->getSamplerEnd(); ++itr) {
+    // Create a gpu resource for the texture.
+    const auto* tex = textures->get(itr->getTexture());
+
+    const auto filterMode = static_cast<SamplerFilterMode>(itr->getFilterMode());
+    auto sampler          = Sampler{device, filterMode};
     DBG_SAMPLER_NAME(m_device, sampler.getVkSampler(), m_asset->getId());
 
     m_descSet.bindImage(dstBinding++, tex->getImage(), sampler);

--- a/src/tria/gfx_vulkan/internal/graphic.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "asset_resource.hpp"
 #include "device.hpp"
-#include "image_sampler.hpp"
+#include "sampler.hpp"
 #include "transferer.hpp"
 #include "tria/asset/graphic.hpp"
 #include "tria/log/api.hpp"
@@ -49,9 +49,9 @@ public:
 private:
   struct TextureData final {
     const Texture* texture;
-    ImageSampler sampler;
+    Sampler sampler;
 
-    TextureData(const Texture* texture, ImageSampler sampler) :
+    TextureData(const Texture* texture, Sampler sampler) :
         texture{texture}, sampler{std::move(sampler)} {}
   };
 

--- a/src/tria/gfx_vulkan/internal/sampler.cpp
+++ b/src/tria/gfx_vulkan/internal/sampler.cpp
@@ -1,14 +1,24 @@
-#include "image_sampler.hpp"
+#include "sampler.hpp"
 
 namespace tria::gfx::internal {
 
 namespace {
 
-[[nodiscard]] auto createVkSampler(const Device* device) -> VkSampler {
-  VkSamplerCreateInfo samplerInfo     = {};
-  samplerInfo.sType                   = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-  samplerInfo.magFilter               = VK_FILTER_LINEAR;
-  samplerInfo.minFilter               = VK_FILTER_LINEAR;
+[[nodiscard]] auto createVkSampler(const Device* device, SamplerFilterMode filterMode)
+    -> VkSampler {
+  VkSamplerCreateInfo samplerInfo = {};
+  samplerInfo.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+  switch (filterMode) {
+  case SamplerFilterMode::Nearest:
+    samplerInfo.magFilter = VK_FILTER_NEAREST;
+    samplerInfo.minFilter = VK_FILTER_NEAREST;
+    break;
+  case SamplerFilterMode::Linear:
+  default:
+    samplerInfo.magFilter = VK_FILTER_LINEAR;
+    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    break;
+  }
   samplerInfo.addressModeU            = VK_SAMPLER_ADDRESS_MODE_REPEAT;
   samplerInfo.addressModeV            = VK_SAMPLER_ADDRESS_MODE_REPEAT;
   samplerInfo.addressModeW            = VK_SAMPLER_ADDRESS_MODE_REPEAT;
@@ -30,11 +40,11 @@ namespace {
 
 } // namespace
 
-ImageSampler::ImageSampler(const Device* device) : m_device{device} {
-  m_vkSampler = createVkSampler(device);
+Sampler::Sampler(const Device* device, SamplerFilterMode filterMode) : m_device{device} {
+  m_vkSampler = createVkSampler(device, filterMode);
 }
 
-ImageSampler::~ImageSampler() {
+Sampler::~Sampler() {
   if (m_vkSampler) {
     vkDestroySampler(m_device->getVkDevice(), m_vkSampler, nullptr);
   }

--- a/src/tria/gfx_vulkan/internal/sampler.hpp
+++ b/src/tria/gfx_vulkan/internal/sampler.hpp
@@ -5,24 +5,29 @@
 
 namespace tria::gfx::internal {
 
+enum class SamplerFilterMode : uint8_t {
+  Nearest = 0,
+  Linear  = 1,
+};
+
 /*
- * Handle to a image resource on the gpu.
+ * Handle to a sampler resource on the gpu.
  */
-class ImageSampler final {
+class Sampler final {
 public:
-  ImageSampler() = default;
-  ImageSampler(const Device* device);
-  ImageSampler(const ImageSampler& rhs) = delete;
-  ImageSampler(ImageSampler&& rhs) noexcept {
+  Sampler() = default;
+  Sampler(const Device* device, SamplerFilterMode filterMode);
+  Sampler(const Sampler& rhs) = delete;
+  Sampler(Sampler&& rhs) noexcept {
     m_device        = rhs.m_device;
     m_vkSampler     = rhs.m_vkSampler;
     rhs.m_vkSampler = nullptr;
   }
-  ~ImageSampler();
+  ~Sampler();
 
-  auto operator=(const ImageSampler& rhs) -> ImageSampler& = delete;
+  auto operator=(const Sampler& rhs) -> Sampler& = delete;
 
-  auto operator=(ImageSampler&& rhs) noexcept -> ImageSampler& {
+  auto operator=(Sampler&& rhs) noexcept -> Sampler& {
     m_device        = rhs.m_device;
     m_vkSampler     = rhs.m_vkSampler;
     rhs.m_vkSampler = nullptr;

--- a/tests/tria/asset/graphic_test.cpp
+++ b/tests/tria/asset/graphic_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE("[asset] - Graphic", "[asset]") {
     });
   }
 
-  SECTION("Textures are optionally loaded as part of the graphic") {
+  SECTION("Texture samplers are optionally loaded as part of the graphic") {
     withTempDir([](const fs::path& dir) {
       writeFile(dir / "test.vert.spv", "");
       writeFile(dir / "test.frag.spv", "");
@@ -41,7 +41,7 @@ TEST_CASE("[asset] - Graphic", "[asset]") {
           "\"vertShader\": \"test.vert.spv\","
           "\"fragShader\": \"test.frag.spv\","
           "\"mesh\": \"test.obj\","
-          "\"textures\": [\"test.ppm\"]"
+          "\"samplers\": [{ \"texture\": \"test.ppm\", \"filter\": \"nearest\"}]"
           "}");
 
       auto db   = Database{nullptr, dir};
@@ -49,8 +49,9 @@ TEST_CASE("[asset] - Graphic", "[asset]") {
       CHECK(gfx->getVertShader()->getShaderKind() == ShaderKind::SpvVertex);
       CHECK(gfx->getFragShader()->getShaderKind() == ShaderKind::SpvFragment);
       CHECK(gfx->getMesh()->getKind() == AssetKind::Mesh);
-      CHECK(gfx->getTextureCount() == 1);
-      CHECK(*(*gfx->getTextureBegin())->getPixelBegin() == Pixel{1, 42, 137, 255});
+      REQUIRE(gfx->getSamplerCount() == 1);
+      CHECK(*gfx->getSamplerBegin()->getTexture()->getPixelBegin() == Pixel{1, 42, 137, 255});
+      CHECK(gfx->getSamplerBegin()->getFilterMode() == TextureSampler::FilterMode::Nearest);
     });
   }
 


### PR DESCRIPTION
Add support for configuring a filter-mode per texture on a graphic.

```c++
enum class FilterMode : uint8_t {
  Nearest = 0,
  Linear  = 1,
};
```

Linear:
```json
{
  "vertShader": "shaders/plain.vert.spv",
  "fragShader": "shaders/plain.frag.spv",
  "mesh": "models/quad.obj",
  "samplers": [
    {
      "texture": "textures/checker.ppm",
      "filter": "linear"
    }
  ]
}
```
![image](https://user-images.githubusercontent.com/14230060/89119103-382e9480-d4b4-11ea-925a-5001c5cb562c.png)


Nearest:
```json
{
  "vertShader": "shaders/plain.vert.spv",
  "fragShader": "shaders/plain.frag.spv",
  "mesh": "models/quad.obj",
  "samplers": [
    {
      "texture": "textures/checker.ppm",
      "filter": "nearest"
    }
  ]
}
```
![image](https://user-images.githubusercontent.com/14230060/89119082-1c2af300-d4b4-11ea-80ac-2482a8feab32.png)

