### PR TITLE
Mipmap generation

### DIFF
--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -163,7 +163,7 @@ Graphic::Graphic(
     const auto* tex = textures->get(itr->getTexture());
 
     const auto filterMode = static_cast<SamplerFilterMode>(itr->getFilterMode());
-    auto sampler          = Sampler{device, filterMode};
+    auto sampler          = Sampler{device, filterMode, tex->getImage().getMipLevels()};
     DBG_SAMPLER_NAME(m_device, sampler.getVkSampler(), m_asset->getId());
 
     m_descSet.bindImage(dstBinding++, tex->getImage(), sampler);

--- a/src/tria/gfx_vulkan/internal/image.cpp
+++ b/src/tria/gfx_vulkan/internal/image.cpp
@@ -6,6 +6,13 @@ namespace tria::gfx::internal {
 
 namespace {
 
+[[nodiscard]] auto calcMipLevels(ImageSize size) noexcept -> uint32_t {
+  // Check how many times we can cut the image in half before both sides hit 1 pixel.
+  const auto biggestSide = std::max(size.x(), size.y());
+  const auto mips        = std::log2(biggestSide);
+  return static_cast<uint32_t>(std::floor(mips)) + 1U; // +1 to include the 'base' image.
+}
+
 [[nodiscard]] auto getVkMemoryRequirements(VkDevice vkDevice, VkImage vkImage)
     -> VkMemoryRequirements {
   VkMemoryRequirements result;
@@ -13,28 +20,35 @@ namespace {
   return result;
 }
 
-[[nodiscard]] auto createVkImage(VkDevice vkDevice, ImageSize size, VkFormat vkFormat) -> VkImage {
+[[nodiscard]] auto createVkImage(
+    VkDevice vkDevice, ImageSize size, VkFormat vkFormat, uint32_t mipLevels, bool genMipMaps)
+    -> VkImage {
   VkImageCreateInfo imageInfo = {};
   imageInfo.sType             = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
   imageInfo.imageType         = VK_IMAGE_TYPE_2D;
   imageInfo.extent.width      = static_cast<uint32_t>(size.x());
   imageInfo.extent.height     = static_cast<uint32_t>(size.y());
   imageInfo.extent.depth      = 1U;
-  imageInfo.mipLevels         = 1U;
+  imageInfo.mipLevels         = mipLevels;
   imageInfo.arrayLayers       = 1U;
   imageInfo.format            = vkFormat;
   imageInfo.tiling            = VK_IMAGE_TILING_OPTIMAL;
   imageInfo.initialLayout     = VK_IMAGE_LAYOUT_UNDEFINED;
   imageInfo.usage             = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-  imageInfo.sharingMode       = VK_SHARING_MODE_EXCLUSIVE;
-  imageInfo.samples           = VK_SAMPLE_COUNT_1_BIT;
+  if (genMipMaps) {
+    // To generate mip-maps we copy from the base image, so we need to transfer from it.
+    imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  }
+  imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  imageInfo.samples     = VK_SAMPLE_COUNT_1_BIT;
 
   VkImage result;
   checkVkResult(vkCreateImage(vkDevice, &imageInfo, nullptr, &result));
   return result;
 }
 
-[[nodiscard]] auto createVkImageView(VkDevice vkDevice, VkImage image, VkFormat format)
+[[nodiscard]] auto
+createVkImageView(VkDevice vkDevice, VkImage image, VkFormat format, uint32_t mipLevels)
     -> VkImageView {
   VkImageViewCreateInfo createInfo           = {};
   createInfo.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -43,7 +57,7 @@ namespace {
   createInfo.format                          = format;
   createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
   createInfo.subresourceRange.baseMipLevel   = 0U;
-  createInfo.subresourceRange.levelCount     = 1U;
+  createInfo.subresourceRange.levelCount     = mipLevels;
   createInfo.subresourceRange.baseArrayLayer = 0U;
   createInfo.subresourceRange.layerCount     = 1U;
 
@@ -54,13 +68,16 @@ namespace {
 
 } // namespace
 
-Image::Image(Device* device, ImageSize size, VkFormat vkFormat) :
-    m_device{device}, m_size{size}, m_vkFormat{vkFormat} {
+Image::Image(Device* device, ImageSize size, VkFormat vkFormat, ImageMipMode mipMode) :
+    m_device{device}, m_size{size}, m_vkFormat{vkFormat}, m_mipMode{mipMode} {
 
   assert(m_device);
 
+  const auto genMipMaps = mipMode == ImageMipMode::Generate;
+  m_mipLevels           = genMipMaps ? calcMipLevels(size) : 1U;
+
   // Create an image.
-  m_vkImage = createVkImage(device->getVkDevice(), size, vkFormat);
+  m_vkImage = createVkImage(device->getVkDevice(), size, vkFormat, m_mipLevels, genMipMaps);
 
   // Allocate device memory for it.
   auto memoryRequirements = getVkMemoryRequirements(device->getVkDevice(), m_vkImage);
@@ -71,7 +88,7 @@ Image::Image(Device* device, ImageSize size, VkFormat vkFormat) :
   m_memory.bindToImage(m_vkImage);
 
   // Create a view over the image.
-  m_vkImageView = createVkImageView(device->getVkDevice(), m_vkImage, vkFormat);
+  m_vkImageView = createVkImageView(device->getVkDevice(), m_vkImage, vkFormat, m_mipLevels);
 }
 
 Image::~Image() {

--- a/src/tria/gfx_vulkan/internal/image.hpp
+++ b/src/tria/gfx_vulkan/internal/image.hpp
@@ -8,18 +8,25 @@ namespace tria::gfx::internal {
 
 using ImageSize = math::Vec<uint16_t, 2>;
 
+enum class ImageMipMode {
+  None,
+  Generate,
+};
+
 /*
  * Handle to a image resource on the gpu.
  */
 class Image final {
 public:
-  Image() = default;
-  Image(Device* device, ImageSize size, VkFormat vkFormat);
+  Image() : m_vkImage{nullptr}, m_vkImageView{nullptr} {}
+  Image(Device* device, ImageSize size, VkFormat vkFormat, ImageMipMode mipMode);
   Image(const Image& rhs) = delete;
   Image(Image&& rhs) noexcept {
     m_device          = rhs.m_device;
     m_size            = rhs.m_size;
     m_vkFormat        = rhs.m_vkFormat;
+    m_mipMode         = rhs.m_mipMode;
+    m_mipLevels       = rhs.m_mipLevels;
     m_vkImage         = rhs.m_vkImage;
     m_vkImageView     = rhs.m_vkImageView;
     m_memory          = std::move(rhs.m_memory);
@@ -34,6 +41,8 @@ public:
     m_device          = rhs.m_device;
     m_size            = rhs.m_size;
     m_vkFormat        = rhs.m_vkFormat;
+    m_mipMode         = rhs.m_mipMode;
+    m_mipLevels       = rhs.m_mipLevels;
     m_vkImage         = rhs.m_vkImage;
     m_vkImageView     = rhs.m_vkImageView;
     m_memory          = std::move(rhs.m_memory);
@@ -45,25 +54,42 @@ public:
   [[nodiscard]] auto getVkImage() const noexcept { return m_vkImage; }
   [[nodiscard]] auto getVkImageView() const noexcept { return m_vkImageView; }
   [[nodiscard]] auto getVkFormat() const noexcept { return m_vkFormat; }
-  [[nodiscard]] auto getSize() const noexcept { return m_size; }
-  [[nodiscard]] auto getPixelCount() const noexcept -> uint32_t {
-    return static_cast<uint32_t>(m_size.x()) * m_size.y();
-  }
   [[nodiscard]] auto getChannelCount() const noexcept {
     return getVkFormatChannelCount(m_vkFormat);
   }
-  [[nodiscard]] auto getDataSize() const noexcept -> uint32_t {
+
+  [[nodiscard]] auto getSize() const noexcept { return m_size; }
+  [[nodiscard]] auto getPixelCount() const noexcept {
+    return static_cast<uint32_t>(m_size.x()) * m_size.y();
+  }
+
+  [[nodiscard]] auto getDataSize() const noexcept {
     return getPixelCount() * getVkFormatSize(m_vkFormat);
   }
   [[nodiscard]] auto getMemSize() const noexcept { return m_memory.getSize(); }
+
+  [[nodiscard]] auto getMipMode() const noexcept { return m_mipMode; }
+  [[nodiscard]] auto getMipLevels() const noexcept { return m_mipLevels; }
 
 private:
   const Device* m_device;
   ImageSize m_size;
   VkFormat m_vkFormat;
+  ImageMipMode m_mipMode;
+  uint32_t m_mipLevels;
   VkImage m_vkImage;
   VkImageView m_vkImageView;
   MemoryBlock m_memory;
 };
+
+[[nodiscard]] constexpr auto getName(ImageMipMode mode) noexcept -> std::string_view {
+  switch (mode) {
+  case ImageMipMode::None:
+    return "none";
+  case ImageMipMode::Generate:
+    return "generate";
+  }
+  return "unknown";
+}
 
 } // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/sampler.cpp
+++ b/src/tria/gfx_vulkan/internal/sampler.cpp
@@ -4,7 +4,8 @@ namespace tria::gfx::internal {
 
 namespace {
 
-[[nodiscard]] auto createVkSampler(const Device* device, SamplerFilterMode filterMode)
+[[nodiscard]] auto
+createVkSampler(const Device* device, SamplerFilterMode filterMode, uint32_t mipLevels)
     -> VkSampler {
   VkSamplerCreateInfo samplerInfo = {};
   samplerInfo.sType               = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -31,7 +32,7 @@ namespace {
   samplerInfo.mipmapMode              = VK_SAMPLER_MIPMAP_MODE_LINEAR;
   samplerInfo.mipLodBias              = 0.0f;
   samplerInfo.minLod                  = 0.0f;
-  samplerInfo.maxLod                  = 0.0f;
+  samplerInfo.maxLod                  = mipLevels;
 
   VkSampler result;
   checkVkResult(vkCreateSampler(device->getVkDevice(), &samplerInfo, nullptr, &result));
@@ -40,8 +41,9 @@ namespace {
 
 } // namespace
 
-Sampler::Sampler(const Device* device, SamplerFilterMode filterMode) : m_device{device} {
-  m_vkSampler = createVkSampler(device, filterMode);
+Sampler::Sampler(const Device* device, SamplerFilterMode filterMode, uint32_t mipLevels) :
+    m_device{device} {
+  m_vkSampler = createVkSampler(device, filterMode, mipLevels);
 }
 
 Sampler::~Sampler() {

--- a/src/tria/gfx_vulkan/internal/sampler.hpp
+++ b/src/tria/gfx_vulkan/internal/sampler.hpp
@@ -16,7 +16,7 @@ enum class SamplerFilterMode : uint8_t {
 class Sampler final {
 public:
   Sampler() = default;
-  Sampler(const Device* device, SamplerFilterMode filterMode);
+  Sampler(const Device* device, SamplerFilterMode filterMode, uint32_t mipLevels);
   Sampler(const Sampler& rhs) = delete;
   Sampler(Sampler&& rhs) noexcept {
     m_device        = rhs.m_device;

--- a/src/tria/gfx_vulkan/internal/texture.cpp
+++ b/src/tria/gfx_vulkan/internal/texture.cpp
@@ -14,7 +14,7 @@ Texture::Texture(log::Logger* logger, Device* device, const asset::Texture* asse
   const auto vkFormat = VK_FORMAT_R8G8B8A8_SRGB;
   assert(getVkFormatSize(vkFormat) == sizeof(asset::Pixel));
   assert(getVkFormatChannelCount(vkFormat) == 4U);
-  m_image = Image{device, m_asset->getSize(), vkFormat};
+  m_image = Image{device, m_asset->getSize(), vkFormat, ImageMipMode::Generate};
 
   DBG_IMG_NAME(device, m_image.getVkImage(), asset->getId());
   DBG_IMGVIEW_NAME(device, m_image.getVkImageView(), asset->getId());
@@ -23,7 +23,9 @@ Texture::Texture(log::Logger* logger, Device* device, const asset::Texture* asse
       logger,
       "Vulkan texture created",
       {"asset", asset->getId()},
-      {"size", asset->getSize()},
+      {"size", m_image.getSize()},
+      {"mipMode", getName(m_image.getMipMode())},
+      {"mipLevels", m_image.getMipLevels()},
       {"format", getVkFormatString(vkFormat)},
       {"memory", log::MemSize{m_image.getMemSize()}});
 }

--- a/src/tria/gfx_vulkan/internal/transferer.cpp
+++ b/src/tria/gfx_vulkan/internal/transferer.cpp
@@ -16,7 +16,9 @@ auto recordImageLayoutTransition(
     VkAccessFlags srcAccess,
     VkAccessFlags dstAccess,
     VkPipelineStageFlags srcStageFlags,
-    VkPipelineStageFlags dstStageFlags) -> void {
+    VkPipelineStageFlags dstStageFlags,
+    uint32_t baseMipLevel,
+    uint32_t mipLevels) -> void {
 
   VkImageMemoryBarrier barrier            = {};
   barrier.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -26,8 +28,8 @@ auto recordImageLayoutTransition(
   barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
   barrier.image                           = img.getVkImage();
   barrier.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
-  barrier.subresourceRange.baseMipLevel   = 0U;
-  barrier.subresourceRange.levelCount     = 1U;
+  barrier.subresourceRange.baseMipLevel   = baseMipLevel;
+  barrier.subresourceRange.levelCount     = mipLevels;
   barrier.subresourceRange.baseArrayLayer = 0U;
   barrier.subresourceRange.layerCount     = 1U;
   barrier.srcAccessMask                   = srcAccess;
@@ -37,7 +39,8 @@ auto recordImageLayoutTransition(
       buffer, srcStageFlags, dstStageFlags, 0U, 0U, nullptr, 0U, nullptr, 1U, &barrier);
 }
 
-auto recordImageToTransferDstLayout(VkCommandBuffer buffer, const Image& img) -> void {
+auto imgLayoutFromUndefToTransferDst(
+    VkCommandBuffer buffer, const Image& img, uint32_t baseMipLevel, uint32_t mipLevels) -> void {
   VkImageLayout oldLayout            = VK_IMAGE_LAYOUT_UNDEFINED;
   VkImageLayout newLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
   VkAccessFlags srcAccess            = 0U;
@@ -45,10 +48,63 @@ auto recordImageToTransferDstLayout(VkCommandBuffer buffer, const Image& img) ->
   VkPipelineStageFlags srcStageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
   VkPipelineStageFlags dstStageFlags = VK_PIPELINE_STAGE_TRANSFER_BIT;
   recordImageLayoutTransition(
-      buffer, img, oldLayout, newLayout, srcAccess, dstAccess, srcStageFlags, dstStageFlags);
+      buffer,
+      img,
+      oldLayout,
+      newLayout,
+      srcAccess,
+      dstAccess,
+      srcStageFlags,
+      dstStageFlags,
+      baseMipLevel,
+      mipLevels);
 }
 
-auto recordImageToShaderReadLayout(VkCommandBuffer buffer, const Image& img) -> void {
+auto imgLayoutFromTransferDstToTransferSrc(
+    VkCommandBuffer buffer, const Image& img, uint32_t baseMipLevel, uint32_t mipLevels) -> void {
+  VkImageLayout oldLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  VkImageLayout newLayout            = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  VkAccessFlags srcAccess            = VK_ACCESS_TRANSFER_WRITE_BIT;
+  VkAccessFlags dstAccess            = VK_ACCESS_TRANSFER_READ_BIT;
+  VkPipelineStageFlags srcStageFlags = VK_PIPELINE_STAGE_TRANSFER_BIT;
+  VkPipelineStageFlags dstStageFlags = VK_PIPELINE_STAGE_TRANSFER_BIT;
+  recordImageLayoutTransition(
+      buffer,
+      img,
+      oldLayout,
+      newLayout,
+      srcAccess,
+      dstAccess,
+      srcStageFlags,
+      dstStageFlags,
+      baseMipLevel,
+      mipLevels);
+}
+
+auto imgLayoutFromTransferSrcToShaderRead(
+    VkCommandBuffer buffer, const Image& img, uint32_t baseMipLevel, uint32_t mipLevels) -> void {
+  VkImageLayout oldLayout            = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  VkImageLayout newLayout            = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+  VkAccessFlags srcAccess            = VK_ACCESS_TRANSFER_READ_BIT;
+  VkAccessFlags dstAccess            = VK_ACCESS_SHADER_READ_BIT;
+  VkPipelineStageFlags srcStageFlags = VK_PIPELINE_STAGE_TRANSFER_BIT;
+  VkPipelineStageFlags dstStageFlags =
+      VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+  recordImageLayoutTransition(
+      buffer,
+      img,
+      oldLayout,
+      newLayout,
+      srcAccess,
+      dstAccess,
+      srcStageFlags,
+      dstStageFlags,
+      baseMipLevel,
+      mipLevels);
+}
+
+auto imgLayoutFromTransferDstToShaderRead(
+    VkCommandBuffer buffer, const Image& img, uint32_t baseMipLevel, uint32_t mipLevels) -> void {
   VkImageLayout oldLayout            = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
   VkImageLayout newLayout            = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
   VkAccessFlags srcAccess            = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -57,7 +113,16 @@ auto recordImageToShaderReadLayout(VkCommandBuffer buffer, const Image& img) -> 
   VkPipelineStageFlags dstStageFlags =
       VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
   recordImageLayoutTransition(
-      buffer, img, oldLayout, newLayout, srcAccess, dstAccess, srcStageFlags, dstStageFlags);
+      buffer,
+      img,
+      oldLayout,
+      newLayout,
+      srcAccess,
+      dstAccess,
+      srcStageFlags,
+      dstStageFlags,
+      baseMipLevel,
+      mipLevels);
 }
 
 } // namespace
@@ -90,6 +155,8 @@ auto Transferer::queueTransfer(const void* data, const Buffer& dst, size_t dstOf
 
 auto Transferer::queueTransfer(const void* data, const Image& dst) -> void {
 
+  assert(dst.getMipLevels() > 0U);
+
   // Upload the data to a transfer buffer.
   const auto size         = dst.getDataSize();
   const auto reqAlignment = std::max<size_t>(
@@ -117,32 +184,74 @@ auto Transferer::record(VkCommandBuffer buffer) noexcept -> void {
   // TODO(bastian): We can do the layout changes in batches and use a single PipelineBarrier to
   // transition all of them instead of using a PipelineBarrier per image.
   for (const auto& work : m_imageWork) {
-    // Transition the image to a layout where it can receive new data.
-    recordImageToTransferDstLayout(buffer, work.dst);
+    const auto& img = work.dst;
+    imgLayoutFromUndefToTransferDst(buffer, img, 0U, img.getMipLevels());
 
-    // Copy the new data to the image.
-    VkBufferImageCopy region               = {};
-    region.bufferOffset                    = work.src.second;
-    region.bufferRowLength                 = 0U; // Fully tightly packed data.
-    region.bufferImageHeight               = 0U; // Fully tightly packed data.
-    region.imageSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
-    region.imageSubresource.mipLevel       = 0U;
-    region.imageSubresource.baseArrayLayer = 0U;
-    region.imageSubresource.layerCount     = 1U;
-    region.imageOffset                     = {0U, 0U, 0U};
-    region.imageExtent.width               = static_cast<uint32_t>(work.dst.getSize().x());
-    region.imageExtent.height              = static_cast<uint32_t>(work.dst.getSize().y());
-    region.imageExtent.depth               = 1U;
+    // Copy the new data to the image (at mip-level 0).
+    VkBufferImageCopy region           = {};
+    region.bufferOffset                = work.src.second;
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.layerCount = 1U;
+    region.imageOffset                 = {0U, 0U, 0U};
+    region.imageExtent.width           = static_cast<uint32_t>(img.getSize().x());
+    region.imageExtent.height          = static_cast<uint32_t>(img.getSize().y());
+    region.imageExtent.depth           = 1U;
     vkCmdCopyBufferToImage(
         buffer,
         work.src.first.getVkBuffer(),
-        work.dst.getVkImage(),
+        img.getVkImage(),
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         1U,
         &region);
 
-    // Transition the image to a layout where it can be read by shaders.
-    recordImageToShaderReadLayout(buffer, work.dst);
+    switch (img.getMipMode()) {
+    case ImageMipMode::Generate:
+      /* Generate the mipmap levels by copying from the previous level at half the size until all
+       * levels have been generated. */
+
+      imgLayoutFromTransferDstToTransferSrc(buffer, img, 0U, 1U);
+
+      for (auto i = 1U; i != img.getMipLevels(); ++i) {
+        // Blit from the previous mip-level.
+        VkImageBlit region               = {};
+        region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        region.srcSubresource.mipLevel   = i - 1U;
+        region.srcSubresource.layerCount = 1U;
+        region.srcOffsets[1].x           = std::max(img.getSize().x() >> (i - 1U), 1);
+        region.srcOffsets[1].y           = std::max(img.getSize().y() >> (i - 1U), 1);
+        region.srcOffsets[1].z           = 1U;
+        region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        region.dstSubresource.mipLevel   = i;
+        region.dstSubresource.layerCount = 1U;
+        region.dstOffsets[1].x           = std::max(img.getSize().x() >> i, 1);
+        region.dstOffsets[1].y           = std::max(img.getSize().y() >> i, 1);
+        region.dstOffsets[1].z           = 1U;
+        vkCmdBlitImage(
+            buffer,
+            img.getVkImage(),
+            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            img.getVkImage(),
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            1U,
+            &region,
+            VK_FILTER_LINEAR);
+
+        // Transition the previous mip-level to shader-read (we no longer need to copy from it).
+        imgLayoutFromTransferSrcToShaderRead(buffer, img, i - 1U, 1U);
+
+        if (i + 1 < img.getMipLevels()) {
+          // Not the last mip-level: transition it to transfer source layout.
+          imgLayoutFromTransferDstToTransferSrc(buffer, img, i, 1U);
+        } else {
+          // Last mip level: transition it to shader-read layout.
+          imgLayoutFromTransferDstToShaderRead(buffer, img, i, 1U);
+        }
+      }
+
+      break;
+    default:
+      imgLayoutFromTransferDstToShaderRead(buffer, img, 0U, img.getMipLevels());
+    }
   }
   m_imageWork.clear();
 }


### PR DESCRIPTION
Add support for generating mipmaps at runtime on the gpu by continuously halving the image until both sizes have hit 1 pixel.

In the future we probably want to generate mipmaps offline and load them directly, but for the time being this is a easy way to get the benefits of mipmapping.  

![image](https://user-images.githubusercontent.com/14230060/89129729-3f7f8d80-d508-11ea-919f-caef41fe8481.png)
