### PR TITLE
Draw statistics

### DIFF
--- a/include/tria/gfx/canvas.hpp
+++ b/include/tria/gfx/canvas.hpp
@@ -8,8 +8,14 @@
 
 namespace tria::gfx {
 
+/* Statistics for a frame that has been completed.
+ */
 struct DrawStats {
-  std::chrono::duration<double> totalGpuTime;
+  std::chrono::duration<double> gpuTime;
+  uint64_t inputAssemblyVerts;
+  uint64_t inputAssemblyPrimitives;
+  uint64_t vertShaderInvocations;
+  uint64_t fragShaderInvocations;
 };
 
 class Context;

--- a/include/tria/gfx/canvas.hpp
+++ b/include/tria/gfx/canvas.hpp
@@ -1,11 +1,16 @@
 #pragma once
 #include "tria/asset/graphic.hpp"
 #include "tria/math/vec.hpp"
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <type_traits>
 
 namespace tria::gfx {
+
+struct DrawStats {
+  std::chrono::duration<double> totalGpuTime;
+};
 
 class Context;
 class NativeCanvas;
@@ -25,6 +30,11 @@ public:
 
   auto operator=(const Canvas& rhs) -> Canvas& = delete;
   auto operator=(Canvas&& rhs) noexcept -> Canvas& = default;
+
+  /* Get statistics for the last draw.
+   * Note: Blocks if the previous draw has not finished executing.
+   */
+  [[nodiscard]] auto getDrawStats() const noexcept -> DrawStats;
 
   /* Begin drawing.
    * Note: Has to be followed with a call to 'drawEnd' before calling 'drawBegin' again.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/renderer.cpp
   tria/gfx_vulkan/internal/sampler.cpp
   tria/gfx_vulkan/internal/shader.cpp
+  tria/gfx_vulkan/internal/stat_recorder.cpp
   tria/gfx_vulkan/internal/stopwatch.cpp
   tria/gfx_vulkan/internal/swapchain.cpp
   tria/gfx_vulkan/internal/texture.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/renderer.cpp
   tria/gfx_vulkan/internal/sampler.cpp
   tria/gfx_vulkan/internal/shader.cpp
+  tria/gfx_vulkan/internal/stopwatch.cpp
   tria/gfx_vulkan/internal/swapchain.cpp
   tria/gfx_vulkan/internal/texture.cpp
   tria/gfx_vulkan/internal/transferer.cpp

--- a/src/tria/gfx_vulkan/canvas.cpp
+++ b/src/tria/gfx_vulkan/canvas.cpp
@@ -7,6 +7,8 @@ Canvas::Canvas(std::unique_ptr<NativeCanvas> native) : m_native{std::move(native
 
 Canvas::~Canvas() = default;
 
+auto Canvas::getDrawStats() const noexcept -> DrawStats { return m_native->getDrawStats(); }
+
 auto Canvas::drawBegin(math::Color clearCol) -> bool { return m_native->drawBegin(clearCol); }
 
 auto Canvas::draw(

--- a/src/tria/gfx_vulkan/internal/debug_utils.hpp
+++ b/src/tria/gfx_vulkan/internal/debug_utils.hpp
@@ -186,3 +186,13 @@
   (DEVICE)->setDebugName(                                                                          \
       VK_OBJECT_TYPE_FENCE, reinterpret_cast<uint64_t>(OBJ), NAME + std::string("_fence"))
 #endif
+
+#if defined(NDEBUG)
+#define DBG_QUERYPOOL_NAME(DEVICE, OBJ, NAME)
+#else
+#define DBG_QUERYPOOL_NAME(DEVICE, OBJ, NAME)                                                      \
+  (DEVICE)->setDebugName(                                                                          \
+      VK_OBJECT_TYPE_QUERY_POOL,                                                                   \
+      reinterpret_cast<uint64_t>(OBJ),                                                             \
+      NAME + std::string("_querypool"))
+#endif

--- a/src/tria/gfx_vulkan/internal/device.cpp
+++ b/src/tria/gfx_vulkan/internal/device.cpp
@@ -86,8 +86,14 @@ constexpr std::array<const char*, 1> g_requiredDeviceExtensions = {
 [[nodiscard]] auto
 createVkDevice(VkPhysicalDevice vkPhysicalDevice, std::set<uint32_t> queueFamilies) -> VkDevice {
 
-  // Set of required device features, nothing enabled at the moment.
-  VkPhysicalDeviceFeatures deviceFeatures = {};
+  VkPhysicalDeviceFeatures supportedFeatures;
+  vkGetPhysicalDeviceFeatures(vkPhysicalDevice, &supportedFeatures);
+
+  VkPhysicalDeviceFeatures featuresToEnable = {};
+  if (supportedFeatures.pipelineStatisticsQuery) {
+    // Optionally enable 'pipelineStatisticsQuery' to gather draw statistics.
+    featuresToEnable.pipelineStatisticsQuery = true;
+  }
 
   // Queues to create on the device.
   auto queueCreateInfos = std::vector<VkDeviceQueueCreateInfo>{};
@@ -110,7 +116,7 @@ createVkDevice(VkPhysicalDevice vkPhysicalDevice, std::set<uint32_t> queueFamili
   createInfo.queueCreateInfoCount    = queueCreateInfos.size();
   createInfo.enabledExtensionCount   = g_requiredDeviceExtensions.size();
   createInfo.ppEnabledExtensionNames = g_requiredDeviceExtensions.data();
-  createInfo.pEnabledFeatures        = &deviceFeatures;
+  createInfo.pEnabledFeatures        = &featuresToEnable;
 
   VkDevice result;
   checkVkResult(vkCreateDevice(vkPhysicalDevice, &createInfo, nullptr, &result));

--- a/src/tria/gfx_vulkan/internal/device.hpp
+++ b/src/tria/gfx_vulkan/internal/device.hpp
@@ -43,6 +43,9 @@ public:
   [[nodiscard]] auto getLimits() const noexcept -> const VkPhysicalDeviceLimits& {
     return m_properties.limits;
   }
+  [[nodiscard]] auto getFeatures() const noexcept -> const VkPhysicalDeviceFeatures& {
+    return m_features;
+  }
   [[nodiscard]] auto getMemProperties() const noexcept -> const VkPhysicalDeviceMemoryProperties& {
     return m_memProperties;
   }

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "graphic.hpp"
+#include "stopwatch.hpp"
 #include "transferer.hpp"
+#include "tria/gfx/canvas.hpp"
 #include "tria/log/api.hpp"
 #include "tria/math/vec.hpp"
 #include "uniform_container.hpp"
@@ -27,6 +29,10 @@ public:
   auto operator=(const Renderer& rhs) -> Renderer& = delete;
   auto operator=(Renderer&& rhs) noexcept -> Renderer& = delete;
 
+  /* Get statistics for the last draw.
+   */
+  [[nodiscard]] auto getDrawStats() const noexcept -> DrawStats;
+
   /* The renderer will wait (on the gpu) for this semaphore before starting to render.
    */
   [[nodiscard]] auto getImageAvailable() const noexcept { return m_imgAvailable; }
@@ -37,7 +43,7 @@ public:
 
   /* Wait until this rendering is ready to record a new frame.
    */
-  auto waitUntilReady() -> void;
+  auto waitUntilReady() const -> void;
 
   /* Begin recording new draw commands to this renderer.
    * Note: Will block if the renderer is currently still rendering.
@@ -69,6 +75,11 @@ private:
   VkFence m_renderDone;
   TransfererUnique m_transferer;
   UniformContainerUnique m_uni;
+  StopwatchUnique m_stopwatch;
+  bool m_hasSubmittedDrawOnce; // Indicates if the renderer has ever submitted a draw.
+
+  TimestampRecord m_drawStart;
+  TimestampRecord m_drawEnd;
 
   /* We record two separate commandbuffers, one for the drawing commands and one for the transfer
    * commands. But at the moment both buffers are submitted to the Graphics queue, in the future we
@@ -82,7 +93,7 @@ private:
   auto bindGraphicDescriptors(const Graphic* graphic, const void* instData, size_t instDataSize)
       -> void;
 
-  auto waitForDone() -> void;
+  auto waitForDone() const -> void;
   auto markNotDone() -> void;
 };
 

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "graphic.hpp"
+#include "stat_recorder.hpp"
 #include "stopwatch.hpp"
 #include "transferer.hpp"
 #include "tria/gfx/canvas.hpp"
@@ -76,6 +77,7 @@ private:
   TransfererUnique m_transferer;
   UniformContainerUnique m_uni;
   StopwatchUnique m_stopwatch;
+  StatRecorderUnique m_statRecorder;
   bool m_hasSubmittedDrawOnce; // Indicates if the renderer has ever submitted a draw.
 
   TimestampRecord m_drawStart;

--- a/src/tria/gfx_vulkan/internal/stat_recorder.cpp
+++ b/src/tria/gfx_vulkan/internal/stat_recorder.cpp
@@ -1,0 +1,100 @@
+#include "stat_recorder.hpp"
+#include "debug_utils.hpp"
+#include "device.hpp"
+#include "tria/math/utils.hpp"
+#include "utils.hpp"
+#include <cassert>
+
+namespace tria::gfx::internal {
+
+namespace {
+
+[[nodiscard]] auto createVkQueryPool(VkDevice vkDevice) -> VkQueryPool {
+  VkQueryPoolCreateInfo createInfo = {};
+  createInfo.sType                 = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+  createInfo.queryType             = VK_QUERY_TYPE_PIPELINE_STATISTICS;
+  createInfo.queryCount            = g_numPipelineStatistics;
+  createInfo.pipelineStatistics =
+      (VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT |
+       VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT |
+       VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT |
+       VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT);
+
+  // 1 query per enabled stat.
+  assert(tria::math::popCount(createInfo.pipelineStatistics) == g_numPipelineStatistics);
+
+  VkQueryPool result;
+  checkVkResult(vkCreateQueryPool(vkDevice, &createInfo, nullptr, &result));
+  return result;
+}
+
+} // namespace
+
+StatRecorder::StatRecorder(log::Logger* logger, const Device* device) :
+    m_logger{logger}, m_device{device}, m_isCapturing{false} {
+  assert(m_device);
+
+  if (m_device->getFeatures().pipelineStatisticsQuery) {
+    m_vkQueryPool = createVkQueryPool(m_device->getVkDevice());
+    DBG_QUERYPOOL_NAME(device, m_vkQueryPool, "statrecorder");
+  } else {
+    m_vkQueryPool = nullptr;
+    LOG_W(m_logger, "Pipeline statistics are not supported on the current device");
+  }
+}
+
+StatRecorder::~StatRecorder() {
+  if (m_vkQueryPool) {
+    vkDestroyQueryPool(m_device->getVkDevice(), m_vkQueryPool, nullptr);
+  }
+}
+
+auto StatRecorder::getStat(StatType statType) noexcept -> uint64_t {
+  assert(static_cast<uint32_t>(statType) < g_numPipelineStatistics);
+
+  if (!m_vkQueryPool) {
+    // Just return zero if the device does not support statistics. Callers can check 'isSupported'
+    // to know if valid statistics will be returned.
+    return 0;
+  }
+
+  if (!m_hasResults) {
+    checkVkResult(vkGetQueryPoolResults(
+        m_device->getVkDevice(),
+        m_vkQueryPool,
+        0U,
+        1U,
+        sizeof(m_results),
+        m_results.data(),
+        sizeof(uint64_t),
+        VK_QUERY_RESULT_64_BIT));
+    m_hasResults = true;
+  }
+  return m_results[static_cast<size_t>(statType)];
+}
+
+auto StatRecorder::reset(VkCommandBuffer vkCmdBuffer) noexcept -> void {
+  if (m_vkQueryPool) {
+    vkCmdResetQueryPool(vkCmdBuffer, m_vkQueryPool, 0U, g_numPipelineStatistics);
+  }
+  m_hasResults = false;
+}
+
+auto StatRecorder::beginCapture(VkCommandBuffer vkCmdBuffer) noexcept -> void {
+  assert(!m_hasResults); // Needs to be reset before starting a new capture.
+  assert(!m_isCapturing);
+  if (m_vkQueryPool) {
+    vkCmdBeginQuery(vkCmdBuffer, m_vkQueryPool, 0U, 0U);
+  }
+  m_isCapturing = true;
+}
+
+auto StatRecorder::endCapture(VkCommandBuffer vkCmdBuffer) noexcept -> void {
+  assert(m_isCapturing);
+  if (m_vkQueryPool) {
+    vkCmdEndQuery(vkCmdBuffer, m_vkQueryPool, 0U);
+  }
+  m_isCapturing = false;
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/stat_recorder.hpp
+++ b/src/tria/gfx_vulkan/internal/stat_recorder.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include "tria/log/api.hpp"
+#include <array>
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+class Device;
+
+/* Pipeline statistic types that are captured.
+ */
+enum StatType {
+  InputAssemblyVerts      = 0U,
+  InputAssemblyPrimitives = 1U,
+  VertShaderInvocations   = 2U,
+  FragShaderInvocations   = 3U,
+};
+
+constexpr auto g_numPipelineStatistics = 4;
+
+/* Utility class for capturing pipline statistics.
+ * At the moment only 1 capture at a time is supported, this could be extended to support multiple
+ * if required.
+ */
+class StatRecorder final {
+public:
+  StatRecorder(log::Logger* logger, const Device* device);
+  StatRecorder(const StatRecorder& rhs)     = delete;
+  StatRecorder(StatRecorder&& rhs) noexcept = delete;
+  ~StatRecorder();
+
+  auto operator=(const StatRecorder& rhs) -> StatRecorder& = delete;
+  auto operator=(StatRecorder&& rhs) noexcept -> StatRecorder& = delete;
+
+  /* Are statistics supported on the gpu?
+   */
+  [[nodiscard]] auto isSupported() const noexcept -> bool { return m_vkQueryPool; }
+
+  /* Get a result statistic for the last capture.
+   * Returns 0 when statistics are not supported.
+   * Note: Make sure that the gpu has finished the work before calling this.
+   */
+  [[nodiscard]] auto getStat(StatType stat) noexcept -> uint64_t;
+
+  /* Reset the capture, call this before starting a new capture.
+   */
+  auto reset(VkCommandBuffer vkCmdBuffer) noexcept -> void;
+
+  /* Begin capuring statistics.
+   * Recorder needs to be reset before calling this again.
+   * Needs to be followed by a call to 'endCapture'.
+   */
+  auto beginCapture(VkCommandBuffer vkCmdBuffer) noexcept -> void;
+
+  /* Stop capturing statistics.
+   */
+  auto endCapture(VkCommandBuffer vkCmdBuffer) noexcept -> void;
+
+private:
+  log::Logger* m_logger;
+  const Device* m_device;
+  VkQueryPool m_vkQueryPool;
+  bool m_isCapturing;
+  bool m_hasResults;
+  std::array<uint64_t, g_numPipelineStatistics> m_results;
+};
+
+using StatRecorderUnique = std::unique_ptr<StatRecorder>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/stopwatch.cpp
+++ b/src/tria/gfx_vulkan/internal/stopwatch.cpp
@@ -64,20 +64,21 @@ auto Stopwatch::getTimestamp(uint32_t id) -> double {
   return static_cast<double>(m_results[id]) * m_device->getLimits().timestampPeriod;
 }
 
-auto Stopwatch::reset(VkCommandBuffer cmdBuffer) noexcept -> void {
+auto Stopwatch::reset(VkCommandBuffer vkCmdBuffer) noexcept -> void {
   if (m_vkQueryPool) {
-    vkCmdResetQueryPool(cmdBuffer, m_vkQueryPool, 0U, g_maxStopwatchTimestamps);
+    vkCmdResetQueryPool(vkCmdBuffer, m_vkQueryPool, 0U, g_maxStopwatchTimestamps);
   }
   m_counter    = 0U;
   m_hasResults = false;
 }
 
-auto Stopwatch::markTimestamp(VkCommandBuffer cmdBuffer) noexcept -> uint32_t {
+auto Stopwatch::markTimestamp(VkCommandBuffer vkCmdBuffer) noexcept -> uint32_t {
   assert(!m_hasResults); // Needs to be reset before marking new timestamps.
   if (m_vkQueryPool) {
     // Note: Record the timestamp after all commands have completely finished executing (bottom of
     // pipe).
-    vkCmdWriteTimestamp(cmdBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_vkQueryPool, m_counter);
+    vkCmdWriteTimestamp(
+        vkCmdBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_vkQueryPool, m_counter);
   }
   return m_counter++;
 }

--- a/src/tria/gfx_vulkan/internal/stopwatch.cpp
+++ b/src/tria/gfx_vulkan/internal/stopwatch.cpp
@@ -1,0 +1,85 @@
+#include "stopwatch.hpp"
+#include "debug_utils.hpp"
+#include "device.hpp"
+#include "utils.hpp"
+#include <cassert>
+
+namespace tria::gfx::internal {
+
+namespace {
+
+[[nodiscard]] auto createVkQueryPool(VkDevice vkDevice, uint32_t maxTimestamps) -> VkQueryPool {
+  VkQueryPoolCreateInfo createInfo = {};
+  createInfo.sType                 = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+  createInfo.queryType             = VK_QUERY_TYPE_TIMESTAMP;
+  createInfo.queryCount            = maxTimestamps;
+
+  VkQueryPool result;
+  checkVkResult(vkCreateQueryPool(vkDevice, &createInfo, nullptr, &result));
+  return result;
+}
+
+} // namespace
+
+Stopwatch::Stopwatch(log::Logger* logger, const Device* device) :
+    m_logger{logger}, m_device{device}, m_counter{0}, m_hasResults{true} {
+  assert(m_device);
+
+  if (m_device->getLimits().timestampComputeAndGraphics) {
+    m_vkQueryPool = createVkQueryPool(m_device->getVkDevice(), g_maxStopwatchTimestamps);
+    DBG_QUERYPOOL_NAME(device, m_vkQueryPool, "stopwatch");
+  } else {
+    m_vkQueryPool = nullptr;
+    LOG_W(m_logger, "Timestamps are not supported on the current device");
+  }
+}
+
+Stopwatch::~Stopwatch() {
+  if (m_vkQueryPool) {
+    vkDestroyQueryPool(m_device->getVkDevice(), m_vkQueryPool, nullptr);
+  }
+}
+
+auto Stopwatch::getTimestamp(uint32_t id) -> double {
+  assert(id < m_counter);
+
+  if (!m_vkQueryPool) {
+    // Just return empty if the device does not support querying timestamps. Callers can check
+    // 'isSupported' to know if valid timestamps will be returned.
+    return 0.0f;
+  }
+
+  if (!m_hasResults) {
+    checkVkResult(vkGetQueryPoolResults(
+        m_device->getVkDevice(),
+        m_vkQueryPool,
+        0U,
+        m_counter,
+        sizeof(m_results),
+        m_results.data(),
+        sizeof(uint64_t),
+        VK_QUERY_RESULT_64_BIT));
+    m_hasResults = true;
+  }
+  return static_cast<double>(m_results[id]) * m_device->getLimits().timestampPeriod;
+}
+
+auto Stopwatch::reset(VkCommandBuffer cmdBuffer) noexcept -> void {
+  if (m_vkQueryPool) {
+    vkCmdResetQueryPool(cmdBuffer, m_vkQueryPool, 0U, g_maxStopwatchTimestamps);
+  }
+  m_counter    = 0U;
+  m_hasResults = false;
+}
+
+auto Stopwatch::markTimestamp(VkCommandBuffer cmdBuffer) noexcept -> uint32_t {
+  assert(!m_hasResults); // Needs to be reset before marking new timestamps.
+  if (m_vkQueryPool) {
+    // Note: Record the timestamp after all commands have completely finished executing (bottom of
+    // pipe).
+    vkCmdWriteTimestamp(cmdBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_vkQueryPool, m_counter);
+  }
+  return m_counter++;
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/stopwatch.hpp
+++ b/src/tria/gfx_vulkan/internal/stopwatch.hpp
@@ -28,20 +28,20 @@ public:
   [[nodiscard]] auto isSupported() const noexcept -> bool { return m_vkQueryPool; }
 
   /* Get the result of a previously marked timestamp (in nanoseconds).
-   * Return 0 when timestamps are not supported.
+   * Returns 0 when timestamps are not supported.
    * Note: Make sure that the gpu has finished the work before calling this.
    */
   [[nodiscard]] auto getTimestamp(TimestampRecord id) -> double;
 
   /* Reset all timestamps, call this before marking new timestamps.
    */
-  auto reset(VkCommandBuffer cmdBuffer) noexcept -> void;
+  auto reset(VkCommandBuffer vkCmdBuffer) noexcept -> void;
 
   /* Mark a timestamp to be recorded.
    * Time will be taken after all previously recorded commands have finished executing.
    * Returns a token that can be used to retreive the timestamp when rendering has finished.
    */
-  [[nodiscard]] auto markTimestamp(VkCommandBuffer cmdBuffer) noexcept -> TimestampRecord;
+  [[nodiscard]] auto markTimestamp(VkCommandBuffer vkCmdBuffer) noexcept -> TimestampRecord;
 
 private:
   log::Logger* m_logger;

--- a/src/tria/gfx_vulkan/internal/stopwatch.hpp
+++ b/src/tria/gfx_vulkan/internal/stopwatch.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include "tria/log/api.hpp"
+#include <array>
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+constexpr auto g_maxStopwatchTimestamps = 64U;
+
+class Device;
+
+using TimestampRecord = uint32_t;
+
+/* Utility class for recording timestamps on the gpu.
+ */
+class Stopwatch final {
+public:
+  Stopwatch(log::Logger* logger, const Device* device);
+  Stopwatch(const Stopwatch& rhs)     = delete;
+  Stopwatch(Stopwatch&& rhs) noexcept = delete;
+  ~Stopwatch();
+
+  auto operator=(const Stopwatch& rhs) -> Stopwatch& = delete;
+  auto operator=(Stopwatch&& rhs) noexcept -> Stopwatch& = delete;
+
+  /* Are timestamps supported on the gpu?
+   */
+  [[nodiscard]] auto isSupported() const noexcept -> bool { return m_vkQueryPool; }
+
+  /* Get the result of a previously marked timestamp (in nanoseconds).
+   * Return 0 when timestamps are not supported.
+   * Note: Make sure that the gpu has finished the work before calling this.
+   */
+  [[nodiscard]] auto getTimestamp(TimestampRecord id) -> double;
+
+  /* Reset all timestamps, call this before marking new timestamps.
+   */
+  auto reset(VkCommandBuffer cmdBuffer) noexcept -> void;
+
+  /* Mark a timestamp to be recorded.
+   * Time will be taken after all previously recorded commands have finished executing.
+   * Returns a token that can be used to retreive the timestamp when rendering has finished.
+   */
+  [[nodiscard]] auto markTimestamp(VkCommandBuffer cmdBuffer) noexcept -> TimestampRecord;
+
+private:
+  log::Logger* m_logger;
+  const Device* m_device;
+  VkQueryPool m_vkQueryPool;
+  uint32_t m_counter;
+  bool m_hasResults;
+  std::array<uint64_t, g_maxStopwatchTimestamps> m_results;
+};
+
+using StopwatchUnique = std::unique_ptr<Stopwatch>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -166,7 +166,13 @@ auto NativeCanvas::drawEnd() -> void {
   }
 
   auto& curRenderer = getCurRenderer();
+
+  // Wait until the previous renderer is finished, reason is that we only want a single frame in
+  // flight on the gpu at the same time.
+  getPrevRenderer().waitUntilReady();
+
   curRenderer.drawEnd();
+
   m_swapchain->presentImage(curRenderer.getImageFinished(), *m_curSwapchainImgIdx);
 
   m_curSwapchainImgIdx = std::nullopt;

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -106,6 +106,12 @@ NativeCanvas::~NativeCanvas() {
   m_device = nullptr;
 }
 
+auto NativeCanvas::getDrawStats() const noexcept -> DrawStats {
+  const auto isDrawActive = m_curSwapchainImgIdx.has_value();
+  const auto& renderer    = isDrawActive ? getPrevRenderer() : getCurRenderer();
+  return renderer.getDrawStats();
+}
+
 auto NativeCanvas::drawBegin(math::Color clearCol) -> bool {
   if (m_curSwapchainImgIdx) {
     throw err::SyncErr{"Unable to begin a draw: draw already active"};

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -35,6 +35,10 @@ public:
   auto operator=(const NativeCanvas& rhs) -> NativeCanvas& = delete;
   auto operator=(NativeCanvas&& rhs) noexcept -> NativeCanvas& = delete;
 
+  /* Get statistics for the last draw.
+   */
+  [[nodiscard]] auto getDrawStats() const noexcept -> DrawStats;
+
   /* Begin recording draw commands.
    * Returns: false if we failed to begin recordering (for example because the window is minimized).
    */
@@ -72,6 +76,10 @@ private:
 
   [[nodiscard]] auto getCurRenderer() const noexcept -> internal::Renderer& {
     return *m_renderers[static_cast<unsigned int>(m_frontRenderer)];
+  }
+
+  [[nodiscard]] auto getPrevRenderer() const noexcept -> internal::Renderer& {
+    return *m_renderers[static_cast<unsigned int>(!m_frontRenderer)];
   }
 
   [[nodiscard]] auto cycleRenderer() noexcept { m_frontRenderer = !m_frontRenderer; }


### PR DESCRIPTION
Add api to get statistics about the previous draw:
```c++
struct DrawStats {
  std::chrono::duration<double> gpuTime; // Execution time on the gpu.
  uint64_t inputAssemblyVerts; // Amount of vertices processed in input-assembly stage.
  uint64_t inputAssemblyPrimitives; // Amount of primitives (triangles) processed in input-assembly stage.
  uint64_t vertShaderInvocations;
  uint64_t fragShaderInvocations;
};

// In Canvas.hpp:

/* Get statistics for the last draw.
  * Note: Blocks if the previous draw has not finished executing.
  */
auto getDrawStats() -> DrawStats;
```
More text in the window title :)
![image](https://user-images.githubusercontent.com/14230060/89828036-22c70380-db61-11ea-84c0-8b07397e9df6.png)

