### PR TITLE
Add debug labels

### DIFF
--- a/include/tria/math/vec.hpp
+++ b/include/tria/math/vec.hpp
@@ -477,19 +477,19 @@ namespace color {
  */
 [[nodiscard]] constexpr auto get(unsigned int i) noexcept -> Color {
   constexpr auto colors = std::array<Color, 14>{
-      silver(),
-      gray(),
       red(),
-      maroon(),
       yellow(),
       olive(),
-      lime(),
-      green(),
+      silver(),
       aqua(),
-      teal(),
+      lime(),
+      maroon(),
       blue(),
+      teal(),
       navy(),
       fuchsia(),
+      green(),
+      gray(),
       purple(),
   };
   return colors[i % colors.size()];

--- a/src/tria/gfx_vulkan/internal/debug_utils.hpp
+++ b/src/tria/gfx_vulkan/internal/debug_utils.hpp
@@ -6,6 +6,19 @@
  */
 
 #if defined(NDEBUG)
+#define DBG_CMD_BEGIN_LABEL(DEVICE, CMDBUFFER, MSG, COLOR)
+#else
+#define DBG_CMD_BEGIN_LABEL(DEVICE, CMDBUFFER, MSG, COLOR)                                         \
+  (DEVICE)->getContext()->beginDebugLabel(CMDBUFFER, MSG, COLOR);
+#endif
+
+#if defined(NDEBUG)
+#define DBG_CMD_END_LABEL(DEVICE, CMDBUFFER)
+#else
+#define DBG_CMD_END_LABEL(DEVICE, CMDBUFFER) (DEVICE)->getContext()->endDebugLabel(CMDBUFFER);
+#endif
+
+#if defined(NDEBUG)
 #define DBG_PHYSDEVICE_NAME(DEVICE, OBJ, NAME)
 #else
 #define DBG_PHYSDEVICE_NAME(DEVICE, OBJ, NAME)                                                     \

--- a/src/tria/gfx_vulkan/internal/device.hpp
+++ b/src/tria/gfx_vulkan/internal/device.hpp
@@ -36,6 +36,7 @@ public:
   auto operator=(const Device& rhs) -> Device& = delete;
   auto operator=(Device&& rhs) noexcept -> Device& = delete;
 
+  [[nodiscard]] auto getContext() const noexcept { return m_context; }
   [[nodiscard]] auto getVkPhysicalDevice() const noexcept { return m_vkPhysicalDevice; }
   [[nodiscard]] auto getVkDevice() const noexcept { return m_vkDevice; }
   [[nodiscard]] auto getVkSurface() const noexcept { return m_vkSurface; }

--- a/src/tria/gfx_vulkan/internal/graphic.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic.hpp
@@ -35,6 +35,8 @@ public:
   auto operator=(const Graphic& rhs) -> Graphic& = delete;
   auto operator=(Graphic&& rhs) -> Graphic& = delete;
 
+  [[nodiscard]] auto getId() const noexcept { return m_asset->getId(); }
+
   /* Note: Call this before accessing any resources from this graphic.
    */
   auto

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -79,6 +79,7 @@ private:
   StopwatchUnique m_stopwatch;
   StatRecorderUnique m_statRecorder;
   bool m_hasSubmittedDrawOnce; // Indicates if the renderer has ever submitted a draw.
+  uint32_t m_drawId;
 
   TimestampRecord m_drawStart;
   TimestampRecord m_drawEnd;

--- a/src/tria/gfx_vulkan/native_context.hpp
+++ b/src/tria/gfx_vulkan/native_context.hpp
@@ -31,6 +31,10 @@ public:
       VkDevice vkDevice, VkObjectType vkType, uint64_t vkHandle, std::string_view name) const
       noexcept -> void;
 
+  auto beginDebugLabel(VkCommandBuffer vkCmdBuffer, std::string_view msg, math::Color color) const
+      noexcept -> void;
+  auto endDebugLabel(VkCommandBuffer vkCmdBuffer) const noexcept -> void;
+
 private:
   log::Logger* m_logger;
   std::string m_appName;


### PR DESCRIPTION
Add debug labels to draw's in debug builds. Useful for debugging using programs like RenderDoc.

RenderDoc output:
![image](https://user-images.githubusercontent.com/14230060/89875763-59833500-dbc6-11ea-827d-6fd447485f53.png)

For scene:
![image](https://user-images.githubusercontent.com/14230060/89875829-6c960500-dbc6-11ea-90f0-da93394ac63a.png)
