### PR TITLE
Configurable clear-flags

### DIFF
--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -28,7 +28,7 @@ struct alignas(16) ParticleData final {
 auto runApp(pal::Platform& platform, asset::Database& db, gfx::Context& gfx) {
 
   auto win    = platform.createWindow({1024, 1024});
-  auto canvas = gfx.createCanvas(&win, gfx::VSyncMode::Enable);
+  auto canvas = gfx.createCanvas(&win, gfx::VSyncMode::Enable, gfx::clearMask(gfx::Clear::Color));
 
   const auto* particleGfx = db.get("graphics/particle.gfx")->downcast<asset::Graphic>();
 
@@ -127,7 +127,7 @@ auto runApp(pal::Platform& platform, asset::Database& db, gfx::Context& gfx) {
     }
 
     // Draw particles.
-    if (canvas.drawBegin(Color{0.3, 0.3, 0.3, 1.0})) {
+    if (canvas.drawBegin()) {
       canvas.draw(particleGfx, particles.begin(), particles.end());
       canvas.drawEnd();
     } else {

--- a/include/tria/gfx/canvas.hpp
+++ b/include/tria/gfx/canvas.hpp
@@ -46,7 +46,7 @@ public:
    * Note: Has to be followed with a call to 'drawEnd' before calling 'drawBegin' again.
    * Returns: false if we failed to begin drawing (for example because the window is minimized).
    */
-  [[nodiscard]] auto drawBegin(math::Color clearCol) -> bool;
+  [[nodiscard]] auto drawBegin(math::Color clearCol = math::color::soothingPurple()) -> bool;
 
   /* Draw a single instance of a graphic without instance data.
    */

--- a/include/tria/gfx/context.hpp
+++ b/include/tria/gfx/context.hpp
@@ -12,6 +12,12 @@ enum class VSyncMode {
   Enable,
 };
 
+using ClearMask = uint8_t;
+
+enum class Clear : uint8_t {
+  Color = 1U << 0U,
+};
+
 /*
  * Abstraction over a graphics context.
  *
@@ -29,7 +35,8 @@ public:
 
   /* Create a canvas to render into that outputs to the given window.
    */
-  [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync) -> Canvas;
+  [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync, ClearMask clear)
+      -> Canvas;
 
 private:
   std::unique_ptr<NativeContext> m_native;
@@ -43,6 +50,20 @@ private:
     return "disable";
   }
   return "unknown";
+}
+
+[[nodiscard]] constexpr auto noneClearMask() noexcept -> ClearMask { return 0U; }
+
+[[nodiscard]] constexpr auto clearMask(Clear clear) noexcept -> ClearMask {
+  return static_cast<ClearMask>(clear);
+}
+
+[[nodiscard]] constexpr auto operator|(Clear lhs, Clear rhs) noexcept -> ClearMask {
+  return clearMask(lhs) | clearMask(rhs);
+}
+
+[[nodiscard]] constexpr auto operator|(ClearMask lhs, Clear rhs) noexcept -> ClearMask {
+  return lhs | clearMask(rhs);
 }
 
 } // namespace tria::gfx

--- a/include/tria/math/vec.hpp
+++ b/include/tria/math/vec.hpp
@@ -472,6 +472,7 @@ namespace color {
 [[nodiscard]] constexpr auto navy() noexcept { return Color{0.0, 0.0, 0.5, 1.0}; }
 [[nodiscard]] constexpr auto fuchsia() noexcept { return Color{1.0, 0.0, 1.0, 1.0}; }
 [[nodiscard]] constexpr auto purple() noexcept { return Color{0.5, 0.0, 0.5, 1.0}; }
+[[nodiscard]] constexpr auto soothingPurple() noexcept { return Color{.188, .039, .141, 1.0}; }
 
 /* Get a color based on a unsigned integer, usefull for getting a color in debug code.
  */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(tria_gfx STATIC
   tria/gfx_vulkan/internal/debug_messenger.cpp
   tria/gfx_vulkan/internal/descriptor_manager.cpp
   tria/gfx_vulkan/internal/device.cpp
+  tria/gfx_vulkan/internal/forward_technique.cpp
   tria/gfx_vulkan/internal/graphic.cpp
   tria/gfx_vulkan/internal/image.cpp
   tria/gfx_vulkan/internal/memory_pool.cpp

--- a/src/tria/gfx_vulkan/context.cpp
+++ b/src/tria/gfx_vulkan/context.cpp
@@ -8,11 +8,11 @@ Context::Context(log::Logger* logger) : m_native{std::make_unique<NativeContext>
 
 Context::~Context() = default;
 
-auto Context::createCanvas(const pal::Window* window, VSyncMode vSync) -> Canvas {
+auto Context::createCanvas(const pal::Window* window, VSyncMode vSync, ClearMask clear) -> Canvas {
   if (!window) {
     throw std::invalid_argument{"Window cannot be null"};
   }
-  return Canvas{m_native->createCanvas(window, vSync)};
+  return Canvas{m_native->createCanvas(window, vSync, clear)};
 }
 
 } // namespace tria::gfx

--- a/src/tria/gfx_vulkan/internal/forward_technique.cpp
+++ b/src/tria/gfx_vulkan/internal/forward_technique.cpp
@@ -12,18 +12,19 @@ namespace tria::gfx::internal {
 
 namespace {
 
-[[nodiscard]] auto createVkRenderPass(const Device* device) -> VkRenderPass {
+[[nodiscard]] auto createVkRenderPass(const Device* device, ClearMask clear) -> VkRenderPass {
   assert(device);
 
   VkAttachmentDescription colorAttachment = {};
   colorAttachment.format                  = device->getVkSurfaceFormat().format;
   colorAttachment.samples                 = VK_SAMPLE_COUNT_1_BIT;
-  colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_CLEAR;
-  colorAttachment.storeOp                 = VK_ATTACHMENT_STORE_OP_STORE;
-  colorAttachment.stencilLoadOp           = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-  colorAttachment.stencilStoreOp          = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-  colorAttachment.initialLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
-  colorAttachment.finalLayout             = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  colorAttachment.loadOp = (clear & clearMask(Clear::Color)) ? VK_ATTACHMENT_LOAD_OP_CLEAR
+                                                             : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  colorAttachment.storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+  colorAttachment.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  colorAttachment.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+  colorAttachment.finalLayout    = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
   std::array<VkAttachmentDescription, 1> attachments = {
       colorAttachment,
@@ -115,9 +116,9 @@ auto beginVkRenderPass(
 
 } // namespace
 
-ForwardTechnique::ForwardTechnique(Device* device) : m_device{device} {
+ForwardTechnique::ForwardTechnique(Device* device, ClearMask clear) : m_device{device} {
   assert(device);
-  m_vkRenderPass = createVkRenderPass(m_device);
+  m_vkRenderPass = createVkRenderPass(m_device, clear);
 }
 
 ForwardTechnique::~ForwardTechnique() {

--- a/src/tria/gfx_vulkan/internal/forward_technique.cpp
+++ b/src/tria/gfx_vulkan/internal/forward_technique.cpp
@@ -1,0 +1,162 @@
+#include "forward_technique.hpp"
+#include "../native_context.hpp"
+#include "debug_utils.hpp"
+#include "device.hpp"
+#include "mesh.hpp"
+#include "utils.hpp"
+#include "vulkan/vulkan_core.h"
+#include <cassert>
+#include <stdexcept>
+
+namespace tria::gfx::internal {
+
+namespace {
+
+[[nodiscard]] auto createVkRenderPass(const Device* device) -> VkRenderPass {
+  assert(device);
+
+  VkAttachmentDescription colorAttachment = {};
+  colorAttachment.format                  = device->getVkSurfaceFormat().format;
+  colorAttachment.samples                 = VK_SAMPLE_COUNT_1_BIT;
+  colorAttachment.loadOp                  = VK_ATTACHMENT_LOAD_OP_CLEAR;
+  colorAttachment.storeOp                 = VK_ATTACHMENT_STORE_OP_STORE;
+  colorAttachment.stencilLoadOp           = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  colorAttachment.stencilStoreOp          = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  colorAttachment.initialLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
+  colorAttachment.finalLayout             = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+  std::array<VkAttachmentDescription, 1> attachments = {
+      colorAttachment,
+  };
+
+  VkAttachmentReference colorAttachmentRef = {};
+  colorAttachmentRef.attachment            = 0;
+  colorAttachmentRef.layout                = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+  VkSubpassDescription subpass = {};
+  subpass.pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS;
+  subpass.colorAttachmentCount = 1;
+  subpass.pColorAttachments    = &colorAttachmentRef;
+
+  VkSubpassDependency dependency = {};
+  dependency.srcSubpass          = VK_SUBPASS_EXTERNAL;
+  dependency.dstSubpass          = 0;
+  dependency.srcStageMask        = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependency.srcAccessMask       = 0;
+  dependency.dstStageMask        = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependency.dstAccessMask       = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+  std::array<VkSubpassDependency, 1> dependencies = {
+      dependency,
+  };
+
+  VkRenderPassCreateInfo renderPassInfo = {};
+  renderPassInfo.sType                  = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+  renderPassInfo.attachmentCount        = attachments.size();
+  renderPassInfo.pAttachments           = attachments.data();
+  renderPassInfo.subpassCount           = 1;
+  renderPassInfo.pSubpasses             = &subpass;
+  renderPassInfo.dependencyCount        = dependencies.size();
+  renderPassInfo.pDependencies          = dependencies.data();
+
+  VkRenderPass result;
+  checkVkResult(vkCreateRenderPass(device->getVkDevice(), &renderPassInfo, nullptr, &result));
+  return result;
+}
+
+[[nodiscard]] auto
+createVkFramebuffer(const Device* device, VkRenderPass vkRenderPass, const Image& colorAttachment) {
+  assert(device);
+
+  std::array<VkImageView, 1> attachments = {
+      colorAttachment.getVkImageView(),
+  };
+  VkFramebufferCreateInfo framebufferInfo = {};
+  framebufferInfo.sType                   = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+  framebufferInfo.renderPass              = vkRenderPass;
+  framebufferInfo.attachmentCount         = attachments.size();
+  framebufferInfo.pAttachments            = attachments.data();
+  framebufferInfo.width                   = colorAttachment.getSize().x();
+  framebufferInfo.height                  = colorAttachment.getSize().y();
+  framebufferInfo.layers                  = 1;
+
+  VkFramebuffer result;
+  checkVkResult(vkCreateFramebuffer(device->getVkDevice(), &framebufferInfo, nullptr, &result));
+  return result;
+}
+
+auto beginVkRenderPass(
+    VkCommandBuffer vkCommandBuffer,
+    VkRenderPass vkRenderPass,
+    VkFramebuffer vkFramebuffer,
+    ImageSize renderSize,
+    math::Color clearCol) -> void {
+
+  static_assert(clearCol.getSize() == 4);
+  VkClearColorValue clearColorValue;
+  clearCol.memcpy(clearColorValue.float32);
+
+  std::array<VkClearValue, 1> clearValues = {
+      VkClearValue{clearColorValue},
+  };
+
+  VkRenderPassBeginInfo renderPassInfo    = {};
+  renderPassInfo.sType                    = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+  renderPassInfo.renderPass               = vkRenderPass;
+  renderPassInfo.framebuffer              = vkFramebuffer;
+  renderPassInfo.renderArea.offset        = {0, 0};
+  renderPassInfo.renderArea.extent.width  = renderSize.x();
+  renderPassInfo.renderArea.extent.height = renderSize.y();
+  renderPassInfo.clearValueCount          = clearValues.size();
+  renderPassInfo.pClearValues             = clearValues.data();
+
+  vkCmdBeginRenderPass(vkCommandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+}
+
+} // namespace
+
+ForwardTechnique::ForwardTechnique(Device* device) : m_device{device} {
+  assert(device);
+  m_vkRenderPass = createVkRenderPass(m_device);
+}
+
+ForwardTechnique::~ForwardTechnique() {
+  vkDestroyRenderPass(m_device->getVkDevice(), m_vkRenderPass, nullptr);
+  for (const VkFramebuffer& vkFramebuffer : m_vkFramebuffers) {
+    vkDestroyFramebuffer(m_device->getVkDevice(), vkFramebuffer, nullptr);
+  }
+}
+
+auto ForwardTechnique::prepareResources(const Swapchain& swapchain) -> void {
+  assert(swapchain.getImageSize().x() > 0);
+  assert(swapchain.getImageSize().y() > 0);
+
+  if (m_swapVersion != swapchain.getVersion() || m_vkFramebuffers.empty()) {
+    assert(swapchain.getImageCount() > 0);
+
+    // Destroy the previous framebuffers.
+    for (const VkFramebuffer& vkFramebuffer : m_vkFramebuffers) {
+      vkDestroyFramebuffer(m_device->getVkDevice(), vkFramebuffer, nullptr);
+    }
+    m_vkFramebuffers.clear();
+
+    // Create new framebuffers.
+    for (auto i = 0U; i != swapchain.getImageCount(); ++i) {
+      const auto& swapImg = swapchain.getImage(i);
+      m_vkFramebuffers.push_back(createVkFramebuffer(m_device, m_vkRenderPass, swapImg));
+    }
+
+    m_size        = swapchain.getImageSize();
+    m_swapVersion = swapchain.getVersion();
+  }
+}
+
+auto ForwardTechnique::beginRenderPass(
+    VkCommandBuffer vkCommandBuffer, SwapchainIdx idx, math::Color clearCol) const noexcept
+    -> void {
+  assert(vkCommandBuffer);
+  assert(idx < m_vkFramebuffers.size());
+  beginVkRenderPass(vkCommandBuffer, m_vkRenderPass, m_vkFramebuffers[idx], m_size, clearCol);
+}
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/forward_technique.hpp
+++ b/src/tria/gfx_vulkan/internal/forward_technique.hpp
@@ -12,7 +12,7 @@ class Device;
  */
 class ForwardTechnique final {
 public:
-  ForwardTechnique(Device* device);
+  ForwardTechnique(Device* device, ClearMask clear);
   ForwardTechnique(const ForwardTechnique& rhs)     = delete;
   ForwardTechnique(ForwardTechnique&& rhs) noexcept = delete;
   ~ForwardTechnique();

--- a/src/tria/gfx_vulkan/internal/forward_technique.hpp
+++ b/src/tria/gfx_vulkan/internal/forward_technique.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include "image.hpp"
+#include "swapchain.hpp"
+#include "tria/log/api.hpp"
+#include <vulkan/vulkan.h>
+
+namespace tria::gfx::internal {
+
+class Device;
+
+/* Technique that renders straight into a swapchain image.
+ */
+class ForwardTechnique final {
+public:
+  ForwardTechnique(Device* device);
+  ForwardTechnique(const ForwardTechnique& rhs)     = delete;
+  ForwardTechnique(ForwardTechnique&& rhs) noexcept = delete;
+  ~ForwardTechnique();
+
+  auto operator=(const ForwardTechnique& rhs) -> ForwardTechnique& = delete;
+  auto operator=(ForwardTechnique&& rhs) noexcept -> ForwardTechnique& = delete;
+
+  /* Render size.
+   */
+  [[nodiscard]] auto getSize() const noexcept { return m_size; }
+  [[nodiscard]] auto getVkRenderPass() const noexcept { return m_vkRenderPass; }
+
+  /* (Re)create any resources required for this technique.
+   */
+  auto prepareResources(const Swapchain& swapchain) -> void;
+
+  auto
+  beginRenderPass(VkCommandBuffer vkCommandBuffer, SwapchainIdx idx, math::Color clearCol) const
+      noexcept -> void;
+
+private:
+  Device* m_device;
+  SwapchainSize m_size;
+  SwapchainVersion m_swapVersion;
+  VkRenderPass m_vkRenderPass;
+  std::vector<VkFramebuffer> m_vkFramebuffers;
+};
+
+using ForwardTechniqueUnique = std::unique_ptr<ForwardTechnique>;
+
+} // namespace tria::gfx::internal

--- a/src/tria/gfx_vulkan/internal/image.cpp
+++ b/src/tria/gfx_vulkan/internal/image.cpp
@@ -21,8 +21,12 @@ namespace {
 }
 
 [[nodiscard]] auto createVkImage(
-    VkDevice vkDevice, ImageSize size, VkFormat vkFormat, uint32_t mipLevels, bool genMipMaps)
-    -> VkImage {
+    VkDevice vkDevice,
+    ImageSize size,
+    VkFormat vkFormat,
+    VkImageUsageFlags imgUsages,
+    uint32_t mipLevels) -> VkImage {
+
   VkImageCreateInfo imageInfo = {};
   imageInfo.sType             = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
   imageInfo.imageType         = VK_IMAGE_TYPE_2D;
@@ -34,28 +38,27 @@ namespace {
   imageInfo.format            = vkFormat;
   imageInfo.tiling            = VK_IMAGE_TILING_OPTIMAL;
   imageInfo.initialLayout     = VK_IMAGE_LAYOUT_UNDEFINED;
-  imageInfo.usage             = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-  if (genMipMaps) {
-    // To generate mip-maps we copy from the base image, so we need to transfer from it.
-    imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-  }
-  imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-  imageInfo.samples     = VK_SAMPLE_COUNT_1_BIT;
+  imageInfo.usage             = imgUsages;
+  imageInfo.sharingMode       = VK_SHARING_MODE_EXCLUSIVE;
+  imageInfo.samples           = VK_SAMPLE_COUNT_1_BIT;
 
   VkImage result;
   checkVkResult(vkCreateImage(vkDevice, &imageInfo, nullptr, &result));
   return result;
 }
 
-[[nodiscard]] auto
-createVkImageView(VkDevice vkDevice, VkImage image, VkFormat format, uint32_t mipLevels)
-    -> VkImageView {
+[[nodiscard]] auto createVkImageView(
+    VkDevice vkDevice,
+    VkImage image,
+    VkFormat format,
+    VkImageAspectFlags aspect,
+    uint32_t mipLevels) -> VkImageView {
   VkImageViewCreateInfo createInfo           = {};
   createInfo.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
   createInfo.image                           = image;
   createInfo.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
   createInfo.format                          = format;
-  createInfo.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+  createInfo.subresourceRange.aspectMask     = aspect;
   createInfo.subresourceRange.baseMipLevel   = 0U;
   createInfo.subresourceRange.levelCount     = mipLevels;
   createInfo.subresourceRange.baseArrayLayer = 0U;
@@ -66,18 +69,55 @@ createVkImageView(VkDevice vkDevice, VkImage image, VkFormat format, uint32_t mi
   return result;
 }
 
+[[nodiscard]] auto getVkImageAspect(ImageType type) noexcept -> VkImageAspectFlags {
+  switch (type) {
+  case ImageType::ColorSource:
+  case ImageType::ColorAttachment:
+  case ImageType::Swapchain:
+    return VK_IMAGE_ASPECT_COLOR_BIT;
+  }
+  return {};
+}
+
+[[nodiscard]] auto getVkImageUsage(ImageType type, bool generatedMipMaps) noexcept
+    -> VkImageUsageFlags {
+  switch (type) {
+  case ImageType::ColorSource: {
+    // Assume that we will be uploading image data from the cpu side.
+    auto usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    if (generatedMipMaps) {
+      // To generate mip-maps we copy from the base image, so we need to transfer from it.
+      usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    }
+    return usage;
+  }
+  case ImageType::ColorAttachment:
+    // Assume that the image will be used as a color attachment.
+    assert(!generatedMipMaps); // Attachments with genenerated mipmaps don't make sense.
+    return VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  case ImageType::Swapchain:
+    assert(false); // Swapchain images cannot be created manually.
+    return {};
+  }
+  return {};
+}
+
 } // namespace
 
-Image::Image(Device* device, ImageSize size, VkFormat vkFormat, ImageMipMode mipMode) :
-    m_device{device}, m_size{size}, m_vkFormat{vkFormat}, m_mipMode{mipMode} {
+Image::Image(
+    Device* device, ImageSize size, VkFormat vkFormat, ImageType type, ImageMipMode mipMode) :
+    m_device{device}, m_size{size}, m_vkFormat{vkFormat}, m_type{type}, m_mipMode{mipMode} {
 
   assert(m_device);
 
   const auto genMipMaps = mipMode == ImageMipMode::Generate;
   m_mipLevels           = genMipMaps ? calcMipLevels(size) : 1U;
 
+  const auto imgAspect = getVkImageAspect(type);
+  const auto imgUsages = getVkImageUsage(type, genMipMaps);
+
   // Create an image.
-  m_vkImage = createVkImage(device->getVkDevice(), size, vkFormat, m_mipLevels, genMipMaps);
+  m_vkImage = createVkImage(device->getVkDevice(), size, vkFormat, imgUsages, m_mipLevels);
 
   // Allocate device memory for it.
   auto memoryRequirements = getVkMemoryRequirements(device->getVkDevice(), m_vkImage);
@@ -88,12 +128,31 @@ Image::Image(Device* device, ImageSize size, VkFormat vkFormat, ImageMipMode mip
   m_memory.bindToImage(m_vkImage);
 
   // Create a view over the image.
-  m_vkImageView = createVkImageView(device->getVkDevice(), m_vkImage, vkFormat, m_mipLevels);
+  m_vkImageView =
+      createVkImageView(device->getVkDevice(), m_vkImage, vkFormat, imgAspect, m_mipLevels);
+}
+
+Image::Image(
+    const Device* device, VkImage vkImage, ImageSize size, VkFormat vkFormat, ImageType type) :
+    m_device{device}, m_size{size}, m_vkFormat{vkFormat}, m_type{type}, m_vkImage{vkImage} {
+
+  assert(m_device);
+
+  // Existing images are assumed to have no mipmaps,
+  m_mipLevels = 1U;
+
+  const auto imgAspect = getVkImageAspect(type);
+
+  // Create a view over the image.
+  m_vkImageView =
+      createVkImageView(device->getVkDevice(), m_vkImage, vkFormat, imgAspect, m_mipLevels);
 }
 
 Image::~Image() {
-  if (m_vkImage) {
+  if (m_vkImage && m_type != ImageType::Swapchain) {
     vkDestroyImage(m_device->getVkDevice(), m_vkImage, nullptr);
+  }
+  if (m_vkImageView) {
     vkDestroyImageView(m_device->getVkDevice(), m_vkImageView, nullptr);
   }
   // Note: Memory is reclaimed by the destructor of MemoryBlock.

--- a/src/tria/gfx_vulkan/internal/image.hpp
+++ b/src/tria/gfx_vulkan/internal/image.hpp
@@ -8,6 +8,12 @@ namespace tria::gfx::internal {
 
 using ImageSize = math::Vec<uint16_t, 2>;
 
+enum class ImageType {
+  ColorSource,
+  ColorAttachment,
+  Swapchain,
+};
+
 enum class ImageMipMode {
   None,
   Generate,
@@ -19,12 +25,14 @@ enum class ImageMipMode {
 class Image final {
 public:
   Image() : m_vkImage{nullptr}, m_vkImageView{nullptr} {}
-  Image(Device* device, ImageSize size, VkFormat vkFormat, ImageMipMode mipMode);
+  Image(Device* device, ImageSize size, VkFormat vkFormat, ImageType type, ImageMipMode mipMode);
+  Image(const Device* device, VkImage vkImage, ImageSize size, VkFormat vkFormat, ImageType type);
   Image(const Image& rhs) = delete;
   Image(Image&& rhs) noexcept {
     m_device          = rhs.m_device;
     m_size            = rhs.m_size;
     m_vkFormat        = rhs.m_vkFormat;
+    m_type            = rhs.m_type;
     m_mipMode         = rhs.m_mipMode;
     m_mipLevels       = rhs.m_mipLevels;
     m_vkImage         = rhs.m_vkImage;
@@ -41,6 +49,7 @@ public:
     m_device          = rhs.m_device;
     m_size            = rhs.m_size;
     m_vkFormat        = rhs.m_vkFormat;
+    m_type            = rhs.m_type;
     m_mipMode         = rhs.m_mipMode;
     m_mipLevels       = rhs.m_mipLevels;
     m_vkImage         = rhs.m_vkImage;
@@ -68,6 +77,8 @@ public:
   }
   [[nodiscard]] auto getMemSize() const noexcept { return m_memory.getSize(); }
 
+  [[nodiscard]] auto getType() const noexcept { return m_type; }
+
   [[nodiscard]] auto getMipMode() const noexcept { return m_mipMode; }
   [[nodiscard]] auto getMipLevels() const noexcept { return m_mipLevels; }
 
@@ -75,12 +86,25 @@ private:
   const Device* m_device;
   ImageSize m_size;
   VkFormat m_vkFormat;
+  ImageType m_type;
   ImageMipMode m_mipMode;
   uint32_t m_mipLevels;
   VkImage m_vkImage;
   VkImageView m_vkImageView;
   MemoryBlock m_memory;
 };
+
+[[nodiscard]] constexpr auto getName(ImageType type) noexcept -> std::string_view {
+  switch (type) {
+  case ImageType::ColorSource:
+    return "color-source";
+  case ImageType::ColorAttachment:
+    return "color-attachment";
+  case ImageType::Swapchain:
+    return "swapchain";
+  }
+  return "unknown";
+}
 
 [[nodiscard]] constexpr auto getName(ImageMipMode mode) noexcept -> std::string_view {
   switch (mode) {

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "forward_technique.hpp"
 #include "graphic.hpp"
 #include "stat_recorder.hpp"
 #include "stopwatch.hpp"
@@ -49,16 +50,13 @@ public:
   /* Begin recording new draw commands to this renderer.
    * Note: Will block if the renderer is currently still rendering.
    */
-  auto drawBegin(
-      VkRenderPass vkRenderPass,
-      VkFramebuffer vkFrameBuffer,
-      VkExtent2D extent,
-      math::Color clearCol) -> void;
+  auto drawBegin(const ForwardTechnique& technique, SwapchainIdx swapIdx, math::Color clearCol)
+      -> void;
 
   /* Record a draw of the given graphic.
    */
   auto draw(
-      VkRenderPass vkRenderPass,
+      const ForwardTechnique& technique,
       const Graphic* graphic,
       const void* uniData,
       size_t uniSize,

--- a/src/tria/gfx_vulkan/internal/swapchain.hpp
+++ b/src/tria/gfx_vulkan/internal/swapchain.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "image.hpp"
 #include "tria/gfx/context.hpp"
 #include "tria/log/api.hpp"
 #include <optional>
@@ -8,6 +9,10 @@
 namespace tria::gfx::internal {
 
 class Device;
+
+using SwapchainIdx     = uint32_t;
+using SwapchainSize    = math::Vec<uint16_t, 2>;
+using SwapchainVersion = uint32_t;
 
 /*
  * Swapchain is responsible for managing the images that are presented to the surface (window).
@@ -22,40 +27,43 @@ public:
   auto operator=(const Swapchain& rhs) -> Swapchain& = delete;
   auto operator=(Swapchain&& rhs) noexcept -> Swapchain& = delete;
 
-  [[nodiscard]] auto getExtent() const noexcept { return m_extent; }
-  [[nodiscard]] auto getVkFramebuffer(uint32_t imageIndex) const -> const VkFramebuffer&;
+  [[nodiscard]] auto getImageSize() const noexcept { return m_size; }
+  [[nodiscard]] auto getImageCount() const noexcept { return m_images.size(); }
+  [[nodiscard]] auto getImage(SwapchainIdx idx) const -> const Image&;
+
+  /* Number that is increment every time the swapchain is recreated, can be used to check if we
+   * should recreate resources that are tied to the swapchain.
+   */
+  [[nodiscard]] auto getVersion() const noexcept { return m_version; }
 
   /* Acquire a new image to render into.
-   * Returns: an index that can be used to retrieve the framebuffer for that image.
+   * Returns: an index that can be used to retrieve the swapchain image.
    * Note: When function returns the image might not be ready yet for rendering into, but all cpu
    * side recording can already be done and the 'imgAvailable' sempahore will fire once the image is
    * ready.
    * Note: if we fail to acquire an image null-optional is returned (can happen when window
    * is minimized for example).
    */
-  [[nodiscard]] auto
-  acquireImage(VkRenderPass vkRenderPass, VkSemaphore imgAvailable, bool forceReinit)
-      -> std::optional<uint32_t>;
+  [[nodiscard]] auto acquireImage(VkSemaphore imgAvailable, bool forceReinit)
+      -> std::optional<SwapchainIdx>;
 
   /* Present a rendered image to the surface (window).
    * Note: actual presenting will only occur when 'imgReady' semaphore is fired, so this can be
    * called before the rendering is done.
    */
-  auto presentImage(VkSemaphore imgReady, uint32_t imageIndex) -> bool;
+  auto presentImage(VkSemaphore imgReady, SwapchainIdx imageIndex) -> bool;
 
 private:
   log::Logger* m_logger;
   const Device* m_device;
+  math::Vec<uint16_t, 2> m_size;
   VSyncMode m_vSync;
-  unsigned int m_imgCount;
-  VkExtent2D m_extent;
   VkSwapchainKHR m_vkSwapchain;
-  std::vector<VkImage> m_vkImages;
-  std::vector<VkImageView> m_vkImageViews;
-  std::vector<VkFramebuffer> m_vkFramebuffers;
+  std::vector<Image> m_images;
   bool m_swapchainOutOfDate;
+  SwapchainVersion m_version;
 
-  auto initSwapchain(VkRenderPass vkRenderPass) -> bool;
+  auto initSwapchain() -> bool;
 };
 
 using SwapchainUnique = std::unique_ptr<Swapchain>;

--- a/src/tria/gfx_vulkan/internal/texture.cpp
+++ b/src/tria/gfx_vulkan/internal/texture.cpp
@@ -14,7 +14,8 @@ Texture::Texture(log::Logger* logger, Device* device, const asset::Texture* asse
   const auto vkFormat = VK_FORMAT_R8G8B8A8_SRGB;
   assert(getVkFormatSize(vkFormat) == sizeof(asset::Pixel));
   assert(getVkFormatChannelCount(vkFormat) == 4U);
-  m_image = Image{device, m_asset->getSize(), vkFormat, ImageMipMode::Generate};
+  m_image =
+      Image{device, m_asset->getSize(), vkFormat, ImageType::ColorSource, ImageMipMode::Generate};
 
   DBG_IMG_NAME(device, m_image.getVkImage(), asset->getId());
   DBG_IMGVIEW_NAME(device, m_image.getVkImageView(), asset->getId());

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -11,7 +11,11 @@ namespace tria::gfx {
 using namespace internal;
 
 NativeCanvas::NativeCanvas(
-    log::Logger* logger, const NativeContext* context, const pal::Window* window, VSyncMode vSync) :
+    log::Logger* logger,
+    const NativeContext* context,
+    const pal::Window* window,
+    VSyncMode vSync,
+    ClearMask clear) :
     m_logger{logger},
     m_context{context},
     m_window{window},
@@ -30,7 +34,7 @@ NativeCanvas::NativeCanvas(
   m_textures = std::make_unique<AssetResource<Texture>>(m_logger, m_device.get());
   m_graphics = std::make_unique<AssetResource<Graphic>>(m_logger, m_device.get());
 
-  m_fwdTechnique = std::make_unique<ForwardTechnique>(m_device.get());
+  m_fwdTechnique = std::make_unique<ForwardTechnique>(m_device.get(), clear);
 
   m_swapchain = std::make_unique<Swapchain>(logger, m_device.get(), vSync);
 

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -28,7 +28,8 @@ public:
       log::Logger* logger,
       const NativeContext* context,
       const pal::Window* window,
-      VSyncMode vSync);
+      VSyncMode vSync,
+      ClearMask clear);
   NativeCanvas(const NativeCanvas& rhs)     = delete;
   NativeCanvas(NativeCanvas&& rhs) noexcept = delete;
   ~NativeCanvas();

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "internal/asset_resource.hpp"
 #include "internal/device.hpp"
+#include "internal/forward_technique.hpp"
 #include "internal/graphic.hpp"
 #include "internal/mesh.hpp"
 #include "internal/renderer.hpp"
@@ -59,11 +60,13 @@ private:
   const NativeContext* m_context;
   const pal::Window* m_window;
   internal::DeviceUnique m_device;
+
   internal::AssetResourceUnique<internal::Shader> m_shaders;
   internal::AssetResourceUnique<internal::Mesh> m_meshes;
   internal::AssetResourceUnique<internal::Texture> m_textures;
   internal::AssetResourceUnique<internal::Graphic> m_graphics;
-  VkRenderPass m_vkRenderPass;
+
+  internal::ForwardTechniqueUnique m_fwdTechnique;
   internal::SwapchainUnique m_swapchain;
 
   // Two renderers to support recording one while is other is currently being rendered on the gpu.

--- a/src/tria/gfx_vulkan/native_context.cpp
+++ b/src/tria/gfx_vulkan/native_context.cpp
@@ -133,9 +133,9 @@ NativeContext::~NativeContext() {
   }
 }
 
-auto NativeContext::createCanvas(const pal::Window* window, VSyncMode vSync)
+auto NativeContext::createCanvas(const pal::Window* window, VSyncMode vSync, ClearMask clear)
     -> std::unique_ptr<NativeCanvas> {
-  return std::make_unique<NativeCanvas>(m_logger, this, window, vSync);
+  return std::make_unique<NativeCanvas>(m_logger, this, window, vSync, clear);
 }
 
 auto NativeContext::setDebugName(

--- a/src/tria/gfx_vulkan/native_context.hpp
+++ b/src/tria/gfx_vulkan/native_context.hpp
@@ -24,7 +24,7 @@ public:
 
   [[nodiscard]] auto getVkInstance() const noexcept { return m_vkInstance; }
 
-  [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync)
+  [[nodiscard]] auto createCanvas(const pal::Window* window, VSyncMode vSync, ClearMask clear)
       -> std::unique_ptr<NativeCanvas>;
 
   auto setDebugName(

--- a/src/tria/pal/native_platform.xcb.cpp
+++ b/src/tria/pal/native_platform.xcb.cpp
@@ -138,9 +138,10 @@ auto NativePlatform::createWindow(WindowSize desiredSize) -> Window {
   const auto winId          = xcb_generate_id(m_xcbCon);
   const auto valMask        = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
   const auto backPixelColor = m_xcbScreen->black_pixel;
-  const auto evtMask        = XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_BUTTON_PRESS |
-      XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_POINTER_MOTION | XCB_EVENT_MASK_KEY_PRESS |
-      XCB_EVENT_MASK_KEY_RELEASE;
+  const auto evtMask =
+      (XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_BUTTON_PRESS |
+       XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_POINTER_MOTION | XCB_EVENT_MASK_KEY_PRESS |
+       XCB_EVENT_MASK_KEY_RELEASE);
   const auto valList = std::array<uint32_t, 2>{
       backPixelColor,
       evtMask,


### PR DESCRIPTION
Add clear-flags argument when creating a graphics surface.
```c++
// New types:

using ClearMask = uint8_t;

enum class Clear : uint8_t {
  Color = 1U << 0U,
};

// New argument to 'createCanvas' in Context.hpp:

auto createCanvas(const pal::Window* window, VSyncMode vSync, ClearMask clear) -> Canvas

// Example usage:

auto canvas = gfx.createCanvas(&win, gfx::VSyncMode::Enable, gfx::clearMask(gfx::Clear::Color));
auto canvas = gfx.createCanvas(&win, gfx::VSyncMode::Enable, gfx::noneClearMask());
```
Currently there is no option to change the clear-mask on an existing canvas, but if required such an api can be added.

Now you can create beautiful artifacts by not-clearing :)
![image](https://user-images.githubusercontent.com/14230060/89984066-6d3fa180-dc81-11ea-9991-bc03a83348fd.png)

This pr also includes some internal restructuring of the graphics library.
