### PR TITLE
Anisotropic filtering

### DIFF
--- a/apps/sandbox_data/graphics/bunny.gfx
+++ b/apps/sandbox_data/graphics/bunny.gfx
@@ -5,7 +5,8 @@
   "samplers": [
     {
       "texture": "textures/checker.ppm",
-      "filter": "nearest"
+      "filter": "nearest",
+      "anisotropy": "none"
     }
   ],
   "blend": "none",

--- a/apps/sandbox_data/graphics/cube.gfx
+++ b/apps/sandbox_data/graphics/cube.gfx
@@ -5,7 +5,8 @@
   "samplers": [
     {
       "texture": "textures/checker.ppm",
-      "filter": "nearest"
+      "filter": "nearest",
+      "anisotropy": "none"
     }
   ],
   "blend": "none",

--- a/apps/sandbox_data/graphics/dragon.gfx
+++ b/apps/sandbox_data/graphics/dragon.gfx
@@ -5,7 +5,8 @@
   "samplers": [
     {
       "texture": "textures/checker.ppm",
-      "filter": "nearest"
+      "filter": "nearest",
+      "anisotropy": "none"
     }
   ],
   "blend": "none",

--- a/apps/sandbox_data/graphics/head.gfx
+++ b/apps/sandbox_data/graphics/head.gfx
@@ -5,7 +5,8 @@
   "samplers": [
     {
       "texture": "assets/head/lambertian.tga",
-      "filter": "linear"
+      "filter": "linear",
+      "anisotropy": "x8"
     }
   ],
   "blend": "none",

--- a/include/tria/asset/graphic.hpp
+++ b/include/tria/asset/graphic.hpp
@@ -23,6 +23,16 @@ enum class FilterMode : uint8_t {
   Linear  = 1, // Choose one of the pixels (sometimes known as 'point' filtering).
 };
 
+/* Mode that is used when appling anisotropic filtering.
+ */
+enum class AnisotropyMode : uint8_t {
+  None = 0, // No anisotropic filtering.
+  X2   = 1, // Anisotropic filtering using 2 samples.
+  X4   = 2, // Anisotropic filtering using 4 samples.
+  X8   = 3, // Anisotropic filtering using 8 samples.
+  X16  = 4, // Anisotropic filtering using 16 samples.
+};
+
 /* Mode that is used when performing depth-tests.
  */
 enum class DepthTestMode : uint8_t {
@@ -37,17 +47,19 @@ enum class DepthTestMode : uint8_t {
 class TextureSampler final {
 public:
   TextureSampler() = delete;
-  TextureSampler(const Texture* texture, FilterMode filterMode) :
-      m_texture{texture}, m_filterMode{filterMode} {
+  TextureSampler(const Texture* texture, FilterMode filterMode, AnisotropyMode anisoMode) :
+      m_texture{texture}, m_filterMode{filterMode}, m_anisoMode{anisoMode} {
     assert(texture);
   }
 
   [[nodiscard]] auto getTexture() const noexcept { return m_texture; }
   [[nodiscard]] auto getFilterMode() const noexcept { return m_filterMode; }
+  [[nodiscard]] auto getAnisoMode() const noexcept { return m_anisoMode; }
 
 private:
   const Texture* m_texture;
   FilterMode m_filterMode;
+  AnisotropyMode m_anisoMode;
 };
 
 /*

--- a/src/tria/asset/internal/graphic_loader.cpp
+++ b/src/tria/asset/internal/graphic_loader.cpp
@@ -19,6 +19,18 @@ namespace {
   return search == table.end() ? std::nullopt : std::optional{search->second};
 }
 
+[[nodiscard]] auto getTextureAnisotropyMode(std::string_view str) -> std::optional<AnisotropyMode> {
+  static const std::unordered_map<std::string_view, AnisotropyMode> table = {
+      {"none", AnisotropyMode::None},
+      {"x2", AnisotropyMode::X2},
+      {"x4", AnisotropyMode::X4},
+      {"x8", AnisotropyMode::X8},
+      {"x16", AnisotropyMode::X16},
+  };
+  const auto search = table.find(str);
+  return search == table.end() ? std::nullopt : std::optional{search->second};
+}
+
 [[nodiscard]] auto getBlendMode(std::string_view str) -> std::optional<BlendMode> {
   static const std::unordered_map<std::string_view, BlendMode> table = {
       {"none", BlendMode::None},
@@ -104,7 +116,18 @@ auto loadGraphic(
         filterMode = *filterModeOpt;
       }
 
-      samplers.push_back(TextureSampler{texture, filterMode});
+      // Anisotropy mode (optional field).
+      auto anisoMode = AnisotropyMode::None;
+      std::string_view anisoModeStr;
+      if (!elem.at("anisotropy").get(anisoModeStr)) {
+        auto anisoModeOpt = getTextureAnisotropyMode(anisoModeStr);
+        if (!anisoModeOpt) {
+          throw err::AssetLoadErr{path, "Unsupported anisotropy filter mode"};
+        }
+        anisoMode = *anisoModeOpt;
+      }
+
+      samplers.push_back(TextureSampler{texture, filterMode, anisoMode});
     }
   }
 

--- a/src/tria/gfx_vulkan/internal/device.cpp
+++ b/src/tria/gfx_vulkan/internal/device.cpp
@@ -108,9 +108,12 @@ createVkDevice(VkPhysicalDevice vkPhysicalDevice, std::set<uint32_t> queueFamili
   vkGetPhysicalDeviceFeatures(vkPhysicalDevice, &supportedFeatures);
 
   VkPhysicalDeviceFeatures featuresToEnable = {};
+  // Optionally enable features.
   if (supportedFeatures.pipelineStatisticsQuery) {
-    // Optionally enable 'pipelineStatisticsQuery' to gather draw statistics.
     featuresToEnable.pipelineStatisticsQuery = true;
+  }
+  if (supportedFeatures.samplerAnisotropy) {
+    featuresToEnable.samplerAnisotropy = true;
   }
 
   // Queues to create on the device.

--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -217,7 +217,8 @@ Graphic::Graphic(
     const auto* tex = textures->get(itr->getTexture());
 
     const auto filterMode = static_cast<SamplerFilterMode>(itr->getFilterMode());
-    auto sampler          = Sampler{device, filterMode, tex->getImage().getMipLevels()};
+    const auto anisoMode  = static_cast<SamplerAnisotropyMode>(itr->getAnisoMode());
+    auto sampler          = Sampler{device, filterMode, anisoMode, tex->getImage().getMipLevels()};
     DBG_SAMPLER_NAME(m_device, sampler.getVkSampler(), m_asset->getId());
 
     m_descSet.attachImage(dstBinding++, tex->getImage(), sampler);

--- a/src/tria/gfx_vulkan/internal/sampler.hpp
+++ b/src/tria/gfx_vulkan/internal/sampler.hpp
@@ -10,13 +10,25 @@ enum class SamplerFilterMode : uint8_t {
   Linear  = 1,
 };
 
+enum class SamplerAnisotropyMode : uint8_t {
+  None = 0,
+  X2   = 1,
+  X4   = 2,
+  X8   = 3,
+  X16  = 4,
+};
+
 /*
  * Handle to a sampler resource on the gpu.
  */
 class Sampler final {
 public:
   Sampler() = default;
-  Sampler(const Device* device, SamplerFilterMode filterMode, uint32_t mipLevels);
+  Sampler(
+      const Device* device,
+      SamplerFilterMode filterMode,
+      SamplerAnisotropyMode anisoMode,
+      uint32_t mipLevels);
   Sampler(const Sampler& rhs) = delete;
   Sampler(Sampler&& rhs) noexcept {
     m_device        = rhs.m_device;

--- a/tests/tria/asset/graphic_test.cpp
+++ b/tests/tria/asset/graphic_test.cpp
@@ -45,7 +45,8 @@ TEST_CASE("[asset] - Graphic", "[asset]") {
           "\"vertShader\": \"test.vert.spv\","
           "\"fragShader\": \"test.frag.spv\","
           "\"mesh\": \"test.obj\","
-          "\"samplers\": [{ \"texture\": \"test.ppm\", \"filter\": \"nearest\"}]"
+          "\"samplers\": [{ \"texture\": \"test.ppm\", \"filter\": \"nearest\", \"anisotropy\": "
+          "\"x4\"}]"
           "}");
 
       auto db   = Database{nullptr, dir};
@@ -56,6 +57,7 @@ TEST_CASE("[asset] - Graphic", "[asset]") {
       REQUIRE(gfx->getSamplerCount() == 1);
       CHECK(*gfx->getSamplerBegin()->getTexture()->getPixelBegin() == Pixel{1, 42, 137, 255});
       CHECK(gfx->getSamplerBegin()->getFilterMode() == FilterMode::Nearest);
+      CHECK(gfx->getSamplerBegin()->getAnisoMode() == AnisotropyMode::X4);
     });
   }
 


### PR DESCRIPTION
Add field to the sampler configuration in the graphic json for enabling anisotropic filtering.

Options are:
```c++
enum class AnisotropyMode : uint8_t {
  None = 0, // No anisotropic filtering.
  X2   = 1, // Anisotropic filtering using 2 samples.
  X4   = 2, // Anisotropic filtering using 4 samples.
  X8   = 3, // Anisotropic filtering using 8 samples.
  X16  = 4, // Anisotropic filtering using 16 samples.
};
```

Example graphic json:
```json
{
  "vertShader": "shaders/obj.vert.spv",
  "fragShader": "shaders/obj_tex.frag.spv",
  "mesh": "assets/bunny.obj",
  "samplers": [
    {
      "texture": "textures/stone.tga",
      "filter": "linear",
      "anisotropy": "x16"
    }
  ],
  "blend": "none",
  "depthTest": "less"
}
```
![anisotrophy](https://user-images.githubusercontent.com/14230060/90330567-63d27400-dfb6-11ea-9fe9-28d2fa517feb.gif)
