### PR TITLE
Reversed-z depth buffer

### DIFF
--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -62,11 +62,10 @@ auto runApp(pal::Platform& platform, asset::Database& db, gfx::Context& gfx) {
   };
 
   constexpr auto camVerFov         = 60.f;
-  constexpr auto camNear           = .1f;
-  constexpr auto camFar            = 1'000.f;
+  constexpr auto camZNear          = .1f;
   constexpr auto camMoveSpeed      = 10.f;
   constexpr auto camRotSensitivity = 3.f;
-  auto cam = scene::Cam3d({-1, 0, -10.f}, identityQuatf(), camVerFov, camNear, camFar);
+  auto cam = scene::Cam3d({-1, 0, -10.f}, identityQuatf(), camVerFov, camZNear);
 
   auto frameNum       = 0U;
   auto frameStartTime = high_resolution_clock::now();

--- a/apps/sandbox_data/shaders/sky.vert
+++ b/apps/sandbox_data/shaders/sky.vert
@@ -13,8 +13,8 @@ INSTANCE_INPUT_BINDING(InstanceData);
 layout(location = 0) out vec3 outWorldDir;
 
 void main() {
-  // At maximum depth filling the clispace.
-  gl_Position = vec4(GET_VERT_POS().xy * 2.0, 1.0, 1.0);
+  // Fullscreen at maximum depth (depth 0 due to reversed-z depthbuffer).
+  gl_Position = vec4(GET_VERT_POS().xy * 2.0, 0.0, 1.0);
 
   // Use the inverse of the viewProj to create a matrix that goes from clipspace to worldspace.
   outWorldDir = (inverse(GET_INST().viewProjMat) * gl_Position).xyz;

--- a/include/tria/scene/cam3d.hpp
+++ b/include/tria/scene/cam3d.hpp
@@ -12,12 +12,8 @@ namespace tria::scene {
 class Cam3d final {
 public:
   Cam3d() = delete;
-  Cam3d(math::Vec3f pos, math::Quatf orient, float fovDeg, float near, float far) :
-      m_pos{pos},
-      m_orient{orient},
-      m_fov{fovDeg * math::degToRad<float>},
-      m_near{near},
-      m_far{far} {}
+  Cam3d(math::Vec3f pos, math::Quatf orient, float fovDeg, float zNear) :
+      m_pos{pos}, m_orient{orient}, m_fov{fovDeg * math::degToRad<float>}, m_zNear{zNear} {}
 
   [[nodiscard]] auto pos() const noexcept -> const math::Vec3f& { return m_pos; }
   [[nodiscard]] auto pos() noexcept -> math::Vec3f& { return m_pos; }
@@ -55,7 +51,7 @@ public:
   /* Projection matrix, brings points from view space into screen space.
    */
   [[nodiscard]] auto getProjMat(float aspect) const noexcept {
-    return math::persProjVerMat4f(m_fov, aspect, m_near, m_far);
+    return math::persProjVerMat4f(m_fov, aspect, m_zNear);
   }
 
   /* View-projection matrix, brings points from world space to screen space.
@@ -68,8 +64,7 @@ private:
   math::Vec3f m_pos;
   math::Quatf m_orient;
   float m_fov;
-  float m_near;
-  float m_far;
+  float m_zNear;
 };
 
 } // namespace tria::scene

--- a/src/tria/gfx_vulkan/internal/device.cpp
+++ b/src/tria/gfx_vulkan/internal/device.cpp
@@ -202,6 +202,7 @@ Device::Device(
     throw err::GfxErr{"Selected vulkan device is missing a presentation queue"};
   }
 
+  // Note: Pick a floating point depth buffer format as we are using a reversed-z depthbuffer.
   const auto foundDepthFormat = pickVkFormat<1>(
       vkPhysicalDevice, {VK_FORMAT_D32_SFLOAT}, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
   if (foundDepthFormat) {
@@ -265,8 +266,8 @@ auto Device::queryVkSurfaceCapabilities() const -> VkSurfaceCapabilitiesKHR {
   return result;
 }
 
-auto Device::setDebugName(VkObjectType vkType, uint64_t vkHandle, std::string_view name) const
-    noexcept -> void {
+auto Device::setDebugName(
+    VkObjectType vkType, uint64_t vkHandle, std::string_view name) const noexcept -> void {
   m_context->setDebugName(m_vkDevice, vkType, vkHandle, name);
 }
 

--- a/src/tria/gfx_vulkan/internal/forward_technique.cpp
+++ b/src/tria/gfx_vulkan/internal/forward_technique.cpp
@@ -123,7 +123,8 @@ auto beginVkRenderPass(
 
   std::array<VkClearValue, 2> clearValues;
   clearCol.memcpy(clearValues[0].color.float32);
-  clearValues[1].depthStencil = {1.0f, 0U}; // Set depth to the 'back' (stencil is not used atm).
+  // Clear depth to zero, reason is we are using a reversed-z depthbuffer.
+  clearValues[1].depthStencil = {0.0f, 0U}; // Depth to zero (stencil is not used).
 
   VkRenderPassBeginInfo renderPassInfo    = {};
   renderPassInfo.sType                    = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;

--- a/src/tria/gfx_vulkan/internal/graphic.cpp
+++ b/src/tria/gfx_vulkan/internal/graphic.cpp
@@ -94,7 +94,8 @@ namespace {
   switch (depthTestMode) {
   case asset::DepthTestMode::Less:
     depthStencil.depthTestEnable = true;
-    depthStencil.depthCompareOp  = VK_COMPARE_OP_LESS;
+    // Use the 'greater' compare op, because we are using a reversed-z depthbuffer.
+    depthStencil.depthCompareOp = VK_COMPARE_OP_GREATER;
     break;
   case asset::DepthTestMode::Always:
     depthStencil.depthTestEnable = true;
@@ -306,8 +307,8 @@ Graphic::Graphic(
   for (const auto& binding : graphicBindings) {
     if (binding.second == DescriptorBindingKind::CombinedImageSampler) {
       if (m_textures.size() == textureIdx) {
-        throw err::GraphicErr{asset->getId(),
-                              "Graphic does not have enough samplers to satisfy shader inputs"};
+        throw err::GraphicErr{
+            asset->getId(), "Graphic does not have enough samplers to satisfy shader inputs"};
       }
       const auto& tex = m_textures[textureIdx++];
       m_descSet.attachImage(binding.first, tex.texture->getImage(), tex.sampler);

--- a/tests/tria/math/mat_test.cpp
+++ b/tests/tria/math/mat_test.cpp
@@ -186,15 +186,20 @@ TEST_CASE("[math] - Mat", "[math]") {
     CHECK(approx(proj * Vec4f{-5.f, 0.f, 0.f, 1.f}, Vec4f{-1.f, 0.f, .5f, 1.f}));
     CHECK(approx(proj * Vec4f{-5.f, 5.f, 0.f, 1.f}, Vec4f{-1.f, -2.f, .5f, 1.f}));
     CHECK(approx(proj * Vec4f{-5.f, -5.f, 0.f, 1.f}, Vec4f{-1.f, 2.f, .5f, 1.f}));
-    CHECK(approx(proj * Vec4f{-5.f, 0.f, -2.f, 1.f}, Vec4f{-1.f, 0.f, 0.f, 1.f}));
-    CHECK(approx(proj * Vec4f{-5.f, 0.f, +2.f, 1.f}, Vec4f{-1.f, 0.f, 1.f, 1.f}));
+
+    // Reversed-z so near is at depth 1 and far is at depth 0.
+    CHECK(approx(proj * Vec4f{-5.f, 0.f, -2.f, 1.f}, Vec4f{-1.f, 0.f, 1.f, 1.f}));
+    CHECK(approx(proj * Vec4f{-5.f, 0.f, +2.f, 1.f}, Vec4f{-1.f, 0.f, 0.f, 1.f}));
   }
 
   SECTION("Perspective projection scales to clip-space") {
     const auto fov  = 90.f * math::degToRad<float>;
-    const auto proj = persProjMat4f(fov, fov, 1.f, 10.f);
-    CHECK(approx(persDivide(proj * Vec4f{0.f, 0.f, 1.f, 1.f}), Vec3f{0.f, 0.f, 0.f}));
-    CHECK(approx(persDivide(proj * Vec4f{0.f, 0.f, 10.f, 1.f}), Vec3f{0.f, 0.f, 1.f}));
+    const auto proj = persProjMat4f(fov, fov, 1.f);
+
+    // Reversed-z depth so, near plane is at depth 1.
+    CHECK(approx(persDivide(proj * Vec4f{0.f, 0.f, 1.f, 1.f}), Vec3f{0.f, 0.f, 1.f}));
+    // Reversed-z depth with infinite far plane, so infinite z is at depth 0.
+    CHECK(approx(persDivide(proj * Vec4f{0.f, 0.f, 999999.f, 1.f}), Vec3f{0.f, 0.f, 0.f}, .001f));
   }
 
   SECTION("Approx checks if two matrices are approximately equal") {


### PR DESCRIPTION
Switch to a reversed-z depth buffer, so near objects are at depth 1 and far objects at depth 0. This has accuracy benefits when using a floating point depth buffer (which we are). The links below give more detail but basically the floating point accuracy (which is highest at 0) and the non-linear nature of the perspective projection cancel each-other out.

Also this switches to a far-plane at infinity for perspective projections, basically because there is no reason not to :) and simplifies some code.

More info:
* https://developer.nvidia.com/content/depth-precision-visualized
* https://outerra.blogspot.com/2012/11/maximizing-depth-buffer-range-and.html