### PR TITLE
Global shader data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,10 @@ set(CXX_FLAGS_WIN32 "\
 # Global compiler flags.
 if(MSVC)
   message(STATUS "Setting msvc compiler flags")
-  set(CMAKE_CXX_FLAGS "/std:c++17 /WX /wd4530 /wd26451 /EHsc ${CXX_FLAGS_WIN32}")
+  set(CMAKE_CXX_FLAGS "/std:c++17 /fp:fast /WX /wd4530 /wd26451 /EHsc ${CXX_FLAGS_WIN32}")
 else()
   message(STATUS "Setting unix compiler flags")
-  set(CXX_FLAGS_SHARED "-std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing")
+  set(CXX_FLAGS_SHARED "-std=c++17 -ffast-math -Werror -Wall -Wextra -fno-strict-aliasing")
   if(${TRIA_PLATFORM} STREQUAL "win32")
     set(CXX_FLAGS_SHARED "${CXX_FLAGS_SHARED} ${CXX_FLAGS_WIN32} -Wno-deprecated-declarations")
   endif()

--- a/apps/sandbox/main.cpp
+++ b/apps/sandbox/main.cpp
@@ -133,25 +133,23 @@ auto runApp(pal::Platform& platform, asset::Database& db, gfx::Context& gfx) {
     }
 
     if (canvas.drawBegin()) {
-      auto vpMat = cam.getViewProjMat(win.getAspect());
+      canvas.bindGlobalData(cam.getViewProjMat(win.getAspect()));
 
       // Draw sky (note also 'clears' the depth).
-      canvas.draw(db.get("graphics/sky.gfx")->downcast<asset::Graphic>(), vpMat);
+      canvas.draw(db.get("graphics/sky.gfx")->downcast<asset::Graphic>());
 
       // Draw objects.
       for (const auto& obj : objs) {
-        canvas.draw(obj.graphic, vpMat * trsMat4f(obj.pos, obj.orient, obj.scale));
+        canvas.draw(obj.graphic, trsMat4f(obj.pos, obj.orient, obj.scale));
       }
 
       // Draw grid.
       struct alignas(16) {
-        Mat4f viewProjMat;
         Vec3f camPos;
         int32_t segments;
       } grid;
-      grid.viewProjMat = vpMat;
-      grid.camPos      = cam.pos();
-      grid.segments    = 250; // Times 4, 2 verts per line and 1 horizontal and 1 vertical line.
+      grid.camPos   = cam.pos();
+      grid.segments = 250; // Times 4, 2 verts per line and 1 horizontal and 1 vertical line.
       canvas.draw(db.get("graphics/grid.gfx")->downcast<asset::Graphic>(), grid.segments * 4, grid);
 
       canvas.drawEnd();
@@ -169,9 +167,9 @@ auto main(int /*unused*/, char* * /*unused*/) -> int {
   pal::setThreadName("tria_main_thread");
   pal::setupInterruptHandler();
 
-  auto logger = log::Logger{
-      log::makeConsolePrettySink(),
-      log::makeFileJsonSink(pal::getCurExecutablePath().replace_extension("log"))};
+  auto logger =
+      log::Logger{log::makeConsolePrettySink(),
+                  log::makeFileJsonSink(pal::getCurExecutablePath().replace_extension("log"))};
 
   int ret;
   try {

--- a/apps/sandbox_data/shaders/grid.vert
+++ b/apps/sandbox_data/shaders/grid.vert
@@ -6,8 +6,12 @@ const uint highlightInterval = 5;
 const vec4 normalColor       = vec4(.1, .1, .1, .4);
 const vec4 highlightColor    = vec4(.1, .1, .1, .9);
 
-struct InstanceData {
+struct GlobalData {
   mat4 viewProjMat;
+};
+GLOBAL_INPUT_BINDING(GlobalData);
+
+struct InstanceData {
   vec3 cameraPos;
   int segments;
 };
@@ -40,5 +44,5 @@ void main() {
 
   float x     = centerX + (isHor ? b : a);
   float z     = centerZ + (isHor ? a : b);
-  gl_Position = GET_INST().viewProjMat * vec4(x, isHighlight ? .01 : 0, z, 1);
+  gl_Position = GET_GLOBAL().viewProjMat * vec4(x, isHighlight ? .01 : 0, z, 1);
 }

--- a/apps/sandbox_data/shaders/include/input.glsl
+++ b/apps/sandbox_data/shaders/include/input.glsl
@@ -1,5 +1,15 @@
-const uint graphicSet  = 0; // 'Per graphic' resources, like the mesh and textures.
-const uint instanceSet = 1; // 'Per instance' resources, like a transformation matrix.
+const uint globalSet   = 0; // 'Global' resources, like a projection matrix.
+const uint graphicSet  = 1; // 'Per graphic' resources, like the mesh and textures.
+const uint instanceSet = 2; // 'Per instance' resources, like a transformation matrix.
+
+/*
+ * Utilities for defining and retreiving global data.
+ */
+
+#define GLOBAL_INPUT_BINDING(DATA)                                                                 \
+  layout(set = globalSet, binding = 0) readonly uniform GlobalBuffer { DATA globalData; }
+
+#define GET_GLOBAL() globalData
 
 /*
  * Utilities for defining and retreiving vertex data.

--- a/apps/sandbox_data/shaders/obj.vert
+++ b/apps/sandbox_data/shaders/obj.vert
@@ -2,6 +2,11 @@
 #extension GL_GOOGLE_include_directive : enable
 #include "include/input.glsl"
 
+struct GlobalData {
+  mat4 viewProjMat;
+};
+GLOBAL_INPUT_BINDING(GlobalData);
+
 VERTEX_INPUT_BINDING();
 
 struct InstanceData {
@@ -13,7 +18,7 @@ layout(location = 0) out vec3 outNrm;
 layout(location = 1) out vec2 outTexcoord;
 
 void main() {
-  gl_Position = GET_INST().mat * vec4(GET_VERT_POS(), 1.0);
+  gl_Position = GET_GLOBAL().viewProjMat * GET_INST().mat * vec4(GET_VERT_POS(), 1.0);
   outNrm      = GET_VERT_NRM();
   outTexcoord = GET_VERT_TEXCOORD();
 }

--- a/apps/sandbox_data/shaders/sky.vert
+++ b/apps/sandbox_data/shaders/sky.vert
@@ -4,10 +4,10 @@
 
 VERTEX_INPUT_BINDING();
 
-struct InstanceData {
+struct GlobalData {
   mat4 viewProjMat;
 };
-INSTANCE_INPUT_BINDING(InstanceData);
+GLOBAL_INPUT_BINDING(GlobalData);
 
 layout(location = 0) out vec3 outWorldDir;
 
@@ -16,5 +16,5 @@ void main() {
   gl_Position = vec4(GET_VERT_POS().xy * 2.0, 0.0, 1.0);
 
   // Use the inverse of the viewProj to create a matrix that goes from clipspace to worldspace.
-  outWorldDir = (inverse(GET_INST().viewProjMat) * gl_Position).xyz;
+  outWorldDir = (inverse(GET_GLOBAL().viewProjMat) * gl_Position).xyz;
 }

--- a/include/tria/gfx/canvas.hpp
+++ b/include/tria/gfx/canvas.hpp
@@ -48,6 +48,22 @@ public:
    */
   [[nodiscard]] auto drawBegin(math::Color clearCol = math::color::soothingPurple()) -> bool;
 
+  /* Bind global data to be used in draws.
+   * Note: Only a single global data binding is active, and does not persist after 'drawEnd'.
+   */
+  template <typename GlobalDataType>
+  auto bindGlobalData(const GlobalDataType& instData) -> void {
+    static_assert(
+        std::is_trivially_copyable_v<GlobalDataType>,
+        "Global data type has to be trivially copyable");
+    bindGlobalData(&instData, sizeof(GlobalDataType));
+  }
+
+  /* Bind global data to be used in draws.
+   * Note: Only a single global data binding is active, and does not persist after 'drawEnd'.
+   */
+  auto bindGlobalData(const void* data, size_t dataSize) -> void;
+
   /* Draw a single instance of a graphic without instance data.
    */
   auto draw(const asset::Graphic* asset) -> void { draw(asset, 0U, nullptr, 0U, 1U); }

--- a/src/tria/gfx_vulkan/canvas.cpp
+++ b/src/tria/gfx_vulkan/canvas.cpp
@@ -11,6 +11,10 @@ auto Canvas::getDrawStats() const noexcept -> DrawStats { return m_native->getDr
 
 auto Canvas::drawBegin(math::Color clearCol) -> bool { return m_native->drawBegin(clearCol); }
 
+auto Canvas::bindGlobalData(const void* data, size_t dataSize) -> void {
+  return m_native->bindGlobalData(data, dataSize);
+}
+
 auto Canvas::draw(
     const asset::Graphic* asset,
     uint32_t indexCount,

--- a/src/tria/gfx_vulkan/internal/graphic.hpp
+++ b/src/tria/gfx_vulkan/internal/graphic.hpp
@@ -14,8 +14,9 @@ class Mesh;
 class Texture;
 class Shader;
 
-constexpr auto g_shaderResourceGraphicSetId  = 0U; // Per graphic resources.
-constexpr auto g_shaderResourceInstanceSetId = 1U; // Per instance resources.
+constexpr auto g_shaderResourceGlobalSetId   = 0U; // Global resources.
+constexpr auto g_shaderResourceGraphicSetId  = 1U; // Per graphic resources.
+constexpr auto g_shaderResourceInstanceSetId = 2U; // Per instance resources.
 
 /* Graphic resource.
  * Holding a vulkan pipeline and dependencies.
@@ -49,6 +50,7 @@ public:
       VkSampleCount sampleCount) const -> void;
 
   [[nodiscard]] auto getMesh() const noexcept { return m_mesh; }
+  [[nodiscard]] auto getUsesGlobalData() const noexcept { return m_usesGlobalData; }
   [[nodiscard]] auto getUsesInstanceData() const noexcept { return m_usesInstanceData; }
   [[nodiscard]] auto getVkPipeline() const noexcept { return m_vkPipeline; }
   [[nodiscard]] auto getVkPipelineLayout() const noexcept { return m_vkPipelineLayout; }
@@ -64,6 +66,7 @@ private:
   const Device* m_device;
   const asset::Graphic* m_asset;
   std::vector<const Shader*> m_shaders;
+  bool m_usesGlobalData;
   bool m_usesInstanceData;
   const Mesh* m_mesh;
 

--- a/src/tria/gfx_vulkan/internal/renderer.hpp
+++ b/src/tria/gfx_vulkan/internal/renderer.hpp
@@ -53,6 +53,8 @@ public:
   auto drawBegin(const ForwardTechnique& technique, SwapchainIdx swapIdx, math::Color clearCol)
       -> void;
 
+  auto bindGlobalData(const void* data, size_t dataSize) -> void;
+
   /* Record a draw of the given graphic.
    */
   auto draw(
@@ -77,7 +79,10 @@ private:
   UniformContainerUnique m_uni;
   StopwatchUnique m_stopwatch;
   StatRecorderUnique m_statRecorder;
+  VkPipelineLayout m_globalPipelineLayout;
+
   bool m_hasSubmittedDrawOnce; // Indicates if the renderer has ever submitted a draw.
+  bool m_hasBoundGlobalData;
   uint32_t m_drawId;
 
   TimestampRecord m_drawStart;

--- a/src/tria/gfx_vulkan/native_canvas.cpp
+++ b/src/tria/gfx_vulkan/native_canvas.cpp
@@ -99,6 +99,13 @@ auto NativeCanvas::drawBegin(math::Color clearCol) -> bool {
   return true;
 }
 
+auto NativeCanvas::bindGlobalData(const void* data, size_t dataSize) -> void {
+  if (!m_curSwapchainImgIdx) {
+    throw err::SyncErr{"Unable to bind global-data: no draw active"};
+  }
+  getCurRenderer().bindGlobalData(data, dataSize);
+}
+
 auto NativeCanvas::draw(
     const asset::Graphic* asset,
     uint32_t indexCount,

--- a/src/tria/gfx_vulkan/native_canvas.hpp
+++ b/src/tria/gfx_vulkan/native_canvas.hpp
@@ -48,6 +48,8 @@ public:
    */
   [[nodiscard]] auto drawBegin(math::Color clearCol) -> bool;
 
+  auto bindGlobalData(const void* data, size_t dataSize) -> void;
+
   /* Record a draw with the given asset.
    */
   auto draw(

--- a/tests/tria/math/quat_test.cpp
+++ b/tests/tria/math/quat_test.cpp
@@ -113,9 +113,12 @@ TEST_CASE("[math] - Quat", "[math]") {
 
   SECTION("Rotating a vector by 42 degrees results in a vector that is 42 degrees away") {
     auto rot = angleAxisQuatf(dir3d::up(), 42.f * math::degToRad<float>);
-    CHECK(approx(angle(dir3d::forward(), rot * dir3d::forward()) * math::radToDeg<float>, 42.f));
     CHECK(approx(
-        angle(dir3d::forward(), rot.getInv() * dir3d::forward()) * math::radToDeg<float>, 42.f));
+        angle(dir3d::forward(), rot * dir3d::forward()) * math::radToDeg<float>, 42.f, .000001f));
+    CHECK(approx(
+        angle(dir3d::forward(), rot.getInv() * dir3d::forward()) * math::radToDeg<float>,
+        42.f,
+        .000001f));
   }
 
   SECTION("Quaternion angle axis over right axis provides the same results as x-rotation matrix") {
@@ -124,7 +127,7 @@ TEST_CASE("[math] - Quat", "[math]") {
 
     auto vec1 = rotMat * Vec4f{.42, 13.37, -42, 0.f};
     auto vec2 = rotQuat * Vec3f{.42, 13.37, -42};
-    CHECK(approx(Vec3f{vec1.x(), vec1.y(), vec1.z()}, vec2, .000001f));
+    CHECK(approx(Vec3f{vec1.x(), vec1.y(), vec1.z()}, vec2, .00001f));
   }
 
   SECTION("Quaternion angle axis over up axis provides the same results as y-rotation matrix") {
@@ -133,7 +136,7 @@ TEST_CASE("[math] - Quat", "[math]") {
 
     auto vec1 = rotMat * Vec4f{.42, 13.37, -42, 0.f};
     auto vec2 = rotQuat * Vec3f{.42, 13.37, -42};
-    CHECK(approx(Vec3f{vec1.x(), vec1.y(), vec1.z()}, vec2, .000001f));
+    CHECK(approx(Vec3f{vec1.x(), vec1.y(), vec1.z()}, vec2, .00001f));
   }
 
   SECTION(
@@ -143,7 +146,7 @@ TEST_CASE("[math] - Quat", "[math]") {
 
     auto vec1 = rotMat * Vec4f{.42, 13.37, -42, 0.f};
     auto vec2 = rotQuat * Vec3f{.42, 13.37, -42};
-    CHECK(approx(Vec3f{vec1.x(), vec1.y(), vec1.z()}, vec2, .000001f));
+    CHECK(approx(Vec3f{vec1.x(), vec1.y(), vec1.z()}, vec2, .00001f));
   }
 
   SECTION(
@@ -187,7 +190,7 @@ TEST_CASE("[math] - Quat", "[math]") {
     auto rotQuat1 = angleAxisQuatf(dir3d::up(), 42.f) * angleAxisQuatf(dir3d::right(), 13.f);
     auto rotQuat2 = quatFromMat(rotMat3f(rotQuat1));
     auto vec      = Vec3f{.42, 13.37, -42};
-    CHECK(approx(rotQuat1 * vec, rotQuat2 * vec, .000001f));
+    CHECK(approx(rotQuat1 * vec, rotQuat2 * vec, .00001f));
   }
 
   SECTION("Quaternion created from orthogonal rotation matrix is normalized") {

--- a/tests/tria/math/vec_test.cpp
+++ b/tests/tria/math/vec_test.cpp
@@ -344,10 +344,9 @@ TEST_CASE("[math] - Vec", "[math]") {
   }
 
   SECTION("rndOnUnitSphere returns unit vectors") {
-    auto maxDev = std::numeric_limits<float>::epsilon() * 2;
-    auto rng    = RngXorWow{42};
+    auto rng = RngXorWow{42};
     for (auto i = 0U; i != 1'000; ++i) {
-      REQUIRE(approx(rndOnUnitSphere3f(rng).getSqrMag(), 1.f, maxDev));
+      REQUIRE(approx(rndOnUnitSphere3f(rng).getSqrMag(), 1.f, .000001f));
     }
   }
 


### PR DESCRIPTION
Adds an api to `Canvas` for binding global data:
```c++
/* Bind global data to be used in draws.
 * Note: Only a single global data binding is active, and does not persist after 'drawEnd'.
 */
template <typename GlobalDataType>
auto bindGlobalData(const GlobalDataType& instData) -> void;

auto bindGlobalData(const void* data, size_t dataSize) -> void;
```
Global data  is available to all shaders until new global data is bound (or until 'drawEnd').

![image](https://user-images.githubusercontent.com/14230060/90985722-69b3f080-e586-11ea-9188-30e061885545.png)

