### PR TITLE
Cache build directory in github ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -86,6 +86,16 @@ jobs:
         echo "g++.exe --version:"
         g++.exe --version
 
+    - name: cache-configuration
+      uses: actions/cache@v2
+      env:
+        CI_CACHE_NAME: ${{matrix.config.image}}-${{matrix.config.arch}}-${{matrix.config.compiler}}
+      with:
+        path: ./build
+        key: ${{env.CI_CACHE_NAME}}-${{github.sha}}
+        restore-keys: |
+          ${{env.CI_CACHE_NAME}}-
+
     - name: configure-unix
       if: matrix.config.os != 'windows'
       run: ./scripts/configure.sh --type Release --tests --lint


### PR DESCRIPTION
Saves some ci time as the dependencies do not need to be fetched every build. However for (better) incremental build support we should investigate integrating [`ccache`](https://ccache.dev/).