### PR TITLE
Mesh vertex tangents

### DIFF
--- a/apps/sandbox_data/shaders/grid.frag
+++ b/apps/sandbox_data/shaders/grid.frag
@@ -2,7 +2,7 @@
 #extension GL_GOOGLE_include_directive : enable
 #include "include/input.glsl"
 
-layout(location = 0) in vec4 inLineColor;
+layout(location = 0) in flat vec4 inLineColor;
 
 layout(location = 0) out vec4 outColor;
 

--- a/apps/sandbox_data/shaders/grid.vert
+++ b/apps/sandbox_data/shaders/grid.vert
@@ -17,7 +17,7 @@ struct InstanceData {
 };
 INSTANCE_INPUT_BINDING(InstanceData);
 
-layout(location = 0) out vec4 outLineColor;
+layout(location = 0) out flat vec4 outLineColor;
 
 void main() {
   // TODO(bastian): Currently the grid is centered on the camera pos, but checking the frustum

--- a/apps/sandbox_data/shaders/include/input.glsl
+++ b/apps/sandbox_data/shaders/include/input.glsl
@@ -7,7 +7,7 @@ const uint instanceSet = 2; // 'Per instance' resources, like a transformation m
  */
 
 #define GLOBAL_INPUT_BINDING(DATA)                                                                 \
-  layout(set = globalSet, binding = 0) readonly uniform GlobalBuffer { DATA globalData; }
+  layout(set = globalSet, binding = 0, std140) readonly uniform GlobalBuffer { DATA globalData; }
 
 #define GET_GLOBAL() globalData
 
@@ -18,16 +18,21 @@ const uint instanceSet = 2; // 'Per instance' resources, like a transformation m
 struct VertexData {
   vec4 posAndU;
   vec4 nrmAndV;
+  vec4 tan;
 };
 
 #define VERTEX_INPUT_BINDING()                                                                     \
-  layout(set = graphicSet, binding = 0) readonly buffer VertexBuffer { VertexData[] vertices; }
+  layout(set = graphicSet, binding = 0, std140) readonly buffer VertexBuffer {                     \
+    VertexData[] vertices;                                                                         \
+  }
 
 #define GET_VERT() vertices[gl_VertexIndex]
 
 #define GET_VERT_POS() GET_VERT().posAndU.xyz
 
 #define GET_VERT_NRM() GET_VERT().nrmAndV.xyz
+
+#define GET_VERT_TAN() GET_VERT().tan
 
 #define GET_VERT_TEXCOORD() vec2(GET_VERT().posAndU.w, GET_VERT().nrmAndV.w)
 
@@ -38,7 +43,7 @@ struct VertexData {
 const uint maxInstances = 2048;
 
 #define INSTANCE_INPUT_BINDING(DATA)                                                               \
-  layout(set = instanceSet, binding = 0) readonly uniform InstanceBuffer {                         \
+  layout(set = instanceSet, binding = 0, std140) readonly uniform InstanceBuffer {                 \
     DATA[maxInstances] instances;                                                                  \
   }
 

--- a/apps/sandbox_data/shaders/include/input.glsl
+++ b/apps/sandbox_data/shaders/include/input.glsl
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_INPUT
+#define INCLUDE_INPUT
+
 const uint globalSet   = 0; // 'Global' resources, like a projection matrix.
 const uint graphicSet  = 1; // 'Per graphic' resources, like the mesh and textures.
 const uint instanceSet = 2; // 'Per instance' resources, like a transformation matrix.
@@ -48,3 +51,5 @@ const uint maxInstances = 2048;
   }
 
 #define GET_INST() instances[gl_InstanceIndex]
+
+#endif

--- a/apps/sandbox_data/shaders/include/utils.glsl
+++ b/apps/sandbox_data/shaders/include/utils.glsl
@@ -1,0 +1,31 @@
+#ifndef INCLUDE_UTILS
+#define INCLUDE_UTILS
+
+/*
+ * Common utilities.
+ */
+
+/* Decode a srgb encoded color to a linear color.
+ * Note: Is a fast approximation, more info: https://en.wikipedia.org/wiki/SRGB
+ */
+vec3 approxDecodeSRGB(vec3 color) {
+  const float inverseGamma = 2.2;
+  return pow(color, vec3(inverseGamma));
+}
+
+/* Encode a linear color to srgb.
+ * Note: Is a fast approximation, more info: https://en.wikipedia.org/wiki/SRGB
+ */
+vec3 approxEncodeSRGB(vec3 color) {
+  const float gamma = 1.0 / 2.2;
+  return pow(color, vec3(gamma));
+}
+
+/* Sample a srgb encoded texture.
+ */
+vec4 textureSRGB(sampler2D texSampler, vec2 texcoord) {
+  const vec4 raw = texture(texSampler, texcoord);
+  return vec4(approxDecodeSRGB(raw.rgb), raw.a);
+}
+
+#endif

--- a/apps/sandbox_data/shaders/include/utils.glsl
+++ b/apps/sandbox_data/shaders/include/utils.glsl
@@ -28,4 +28,15 @@ vec4 textureSRGB(sampler2D texSampler, vec2 texcoord) {
   return vec4(approxDecodeSRGB(raw.rgb), raw.a);
 }
 
+/* Sample a normal texture in tangent space and convert it to the axis system formed by the given
+ * normal and tangent, 'w' component of the tangent indicates the handedness.
+ */
+vec3 textureNrm(sampler2D nrmSampler, vec2 texcoord, vec3 normal, vec4 tangent) {
+  const vec3 t   = normalize(tangent.xyz);             // tangent.
+  const vec3 n   = normalize(normal);                  // normal.
+  const vec3 b   = normalize(cross(n, t) * tangent.w); // binormal.
+  const mat3 tbn = mat3(t, b, n);
+  return tbn * (texture(nrmSampler, texcoord).xyz * 2.0 - 1.0);
+}
+
 #endif

--- a/apps/sandbox_data/shaders/obj.vert
+++ b/apps/sandbox_data/shaders/obj.vert
@@ -14,11 +14,13 @@ struct InstanceData {
 };
 INSTANCE_INPUT_BINDING(InstanceData);
 
-layout(location = 0) out vec3 outNrm;
-layout(location = 1) out vec2 outTexcoord;
+layout(location = 0) out vec3 outWorldNrm;
+layout(location = 1) out vec4 outWorldTan;
+layout(location = 2) out vec2 outTexcoord;
 
 void main() {
   gl_Position = GET_GLOBAL().viewProjMat * GET_INST().mat * vec4(GET_VERT_POS(), 1.0);
-  outNrm      = GET_VERT_NRM();
+  outWorldNrm = mat3(GET_INST().mat) * GET_VERT_NRM();
+  outWorldTan = vec4(mat3(GET_INST().mat) * GET_VERT_TAN().xyz, GET_VERT_TAN().w);
   outTexcoord = GET_VERT_TEXCOORD();
 }

--- a/apps/sandbox_data/shaders/obj_nrm.frag
+++ b/apps/sandbox_data/shaders/obj_nrm.frag
@@ -2,9 +2,10 @@
 #extension GL_GOOGLE_include_directive : enable
 #include "include/input.glsl"
 
-layout(location = 0) in vec3 inNrm;
-layout(location = 1) in vec2 inTexcoord;
+layout(location = 0) in vec3 inWorldNrm;
+layout(location = 1) in vec4 inWorldTan;
+layout(location = 2) in vec2 inTexcoord;
 
 layout(location = 0) out vec4 outColor;
 
-void main() { outColor = vec4((inNrm + 1.0) * .5, 1.0); }
+void main() { outColor = vec4((normalize(inWorldNrm) + 1.0) * .5, 1.0); }

--- a/apps/sandbox_data/shaders/obj_tex.frag
+++ b/apps/sandbox_data/shaders/obj_tex.frag
@@ -4,8 +4,9 @@
 
 layout(set = graphicSet, binding = 1) uniform sampler2D texSampler;
 
-layout(location = 0) in vec3 inNrm;
-layout(location = 1) in vec2 inTexcoord;
+layout(location = 0) in vec3 inWorldNrm;
+layout(location = 1) in vec4 inWorldTan;
+layout(location = 2) in vec2 inTexcoord;
 
 layout(location = 0) out vec4 outColor;
 

--- a/apps/sandbox_data/shaders/obj_tex.frag
+++ b/apps/sandbox_data/shaders/obj_tex.frag
@@ -1,6 +1,7 @@
 #version 450
 #extension GL_GOOGLE_include_directive : enable
 #include "include/input.glsl"
+#include "include/utils.glsl"
 
 layout(set = graphicSet, binding = 1) uniform sampler2D texSampler;
 
@@ -10,4 +11,4 @@ layout(location = 2) in vec2 inTexcoord;
 
 layout(location = 0) out vec4 outColor;
 
-void main() { outColor = texture(texSampler, inTexcoord); }
+void main() { outColor = textureSRGB(texSampler, inTexcoord); }

--- a/apps/sandbox_data/shaders/obj_tex_nrm.frag
+++ b/apps/sandbox_data/shaders/obj_tex_nrm.frag
@@ -1,0 +1,22 @@
+#version 450
+#extension GL_GOOGLE_include_directive : enable
+#include "include/input.glsl"
+#include "include/utils.glsl"
+
+layout(set = graphicSet, binding = 1) uniform sampler2D texSampler;
+layout(set = graphicSet, binding = 2) uniform sampler2D nrmSampler;
+
+layout(location = 0) in vec3 inWorldNrm;
+layout(location = 1) in vec4 inWorldTan;
+layout(location = 2) in vec2 inTexcoord;
+
+layout(location = 0) out vec4 outColor;
+
+void main() {
+  vec3 normal          = textureNrm(nrmSampler, inTexcoord, inWorldNrm, inWorldTan);
+  vec3 lightDir        = normalize(vec3(0.2, 1.0, -0.5));
+  float lightIntensity = clamp(dot(normal, lightDir), 0.1, 1.0);
+
+  vec4 diffuse = textureSRGB(texSampler, inTexcoord);
+  outColor     = diffuse * lightIntensity;
+}

--- a/include/tria/asset/mesh.hpp
+++ b/include/tria/asset/mesh.hpp
@@ -13,14 +13,18 @@ using IndexType = uint32_t;
 struct Vertex final {
   math::Vec3f position;
   math::Vec3f normal;
+  math::Vec4f tangent; // 'w' indicates the handedness, '1' or '-1'.
   math::Vec2f texcoord;
 
   constexpr Vertex() noexcept = default;
-  constexpr Vertex(math::Vec3f position, math::Vec3f normal, math::Vec2f texcoord) :
-      position{position}, normal{normal}, texcoord{texcoord} {}
+  constexpr Vertex(
+      math::Vec3f position, math::Vec3f normal, math::Vec4f tangent, math::Vec2f texcoord) :
+      position{position}, normal{normal}, tangent{tangent}, texcoord{texcoord} {}
 
   [[nodiscard]] constexpr auto operator==(const Vertex& rhs) const noexcept -> bool {
-    return position == rhs.position && normal == rhs.normal && texcoord == rhs.texcoord;
+    return (
+        position == rhs.position && normal == rhs.normal && rhs.tangent == rhs.tangent &&
+        texcoord == rhs.texcoord);
   }
 
   [[nodiscard]] constexpr auto operator!=(const Vertex& rhs) const noexcept -> bool {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(tria_asset STATIC
   tria/asset/internal/json.cpp
   tria/asset/internal/loader.cpp
   tria/asset/internal/mesh_obj_loader.cpp
+  tria/asset/internal/mesh_utils.cpp
   tria/asset/internal/raw_asset_loader.cpp
   tria/asset/internal/shader_spv_loader.cpp
   tria/asset/internal/texture_ppm_loader.cpp

--- a/src/tria/asset/internal/mesh_obj_loader.cpp
+++ b/src/tria/asset/internal/mesh_obj_loader.cpp
@@ -1,5 +1,6 @@
 #include "loader.hpp"
 #include "mesh_builder.hpp"
+#include "mesh_utils.hpp"
 #include "tria/asset/mesh.hpp"
 #include "tria/math/vec.hpp"
 #include <limits>
@@ -418,11 +419,14 @@ auto loadMeshObj(log::Logger* /*unused*/, DatabaseImpl* /*unused*/, AssetId id, 
       const auto vertCTexcoord = lookupTexcoord(objData, vertC);
       const auto vertCNorm     = face.useFaceNormal ? faceNrm : objData.normals[vertC.normalIndex];
 
-      meshBuilder.pushVertex(Vertex{vertAPos, vertANorm, vertATexcoord});
-      meshBuilder.pushVertex(Vertex{vertBPos, vertBNorm, vertBTexcoord});
-      meshBuilder.pushVertex(Vertex{vertCPos, vertCNorm, vertCTexcoord});
+      meshBuilder.pushVertex(Vertex{vertAPos, vertANorm, {}, vertATexcoord});
+      meshBuilder.pushVertex(Vertex{vertBPos, vertBNorm, {}, vertBTexcoord});
+      meshBuilder.pushVertex(Vertex{vertCPos, vertCNorm, {}, vertCTexcoord});
     }
   }
+
+  // Compute smooth tangents based on the positions and the texcoords.
+  computeTangents(vertices, indices);
 
   assert(vertices.size() <= numMeshVertices);
   assert(indices.size() == numMeshVertices);

--- a/src/tria/asset/internal/mesh_utils.cpp
+++ b/src/tria/asset/internal/mesh_utils.cpp
@@ -1,0 +1,74 @@
+#include "mesh_utils.hpp"
+#include "tria/math/vec.hpp"
+
+namespace tria::asset::internal {
+
+auto computeTangents(
+    math::PodVector<Vertex>& vertices, const math::PodVector<IndexType>& indices) noexcept -> void {
+
+  /* Calculate a tangent and bitangent per triangle and accumlate the results per vertex. At the end
+   * we compute a tangent per vertex by averaging the tangent and bitangents, this has the effect of
+   * smoothing the tangents for vertices that are shared by multiple triangles.
+   */
+
+  auto* buffer = static_cast<math::Vec3f*>(std::calloc(vertices.size() * 2U, sizeof(math::Vec3f)));
+  auto* tangents   = buffer;
+  auto* bitangents = buffer + vertices.size();
+
+  assert((indices.size() % 3U) == 0U); // Input has to be triangles.
+
+  // Calculate per triangle tangents and bitangents and accumulate them per vertex.
+  for (auto i = 0U; i != indices.size(); i += 3) {
+    const auto& vA = vertices[indices[i]];
+    const auto& vB = vertices[indices[i + 1U]];
+    const auto& vC = vertices[indices[i + 2U]];
+
+    const auto deltaPos1 = vB.position - vA.position;
+    const auto deltaPos2 = vC.position - vA.position;
+    const auto deltaTex1 = vB.texcoord - vA.texcoord;
+    const auto deltaTex2 = vC.texcoord - vA.texcoord;
+
+    const auto s = (deltaTex1.x() * deltaTex2.y() - deltaTex2.x() * deltaTex1.y());
+    if (math::approxZero(s)) {
+      // Not possible to calculate a tangent/bitangent here, triangle has zero texcoord area.
+      continue;
+    }
+
+    const auto tan = (deltaPos1 * deltaTex2.y() - deltaPos2 * deltaTex1.y()) / s;
+    tangents[indices[i]] += tan;
+    tangents[indices[i + 1U]] += tan;
+    tangents[indices[i + 2U]] += tan;
+
+    const auto bitan = (deltaPos2 * deltaTex1.x() - deltaPos1 * deltaTex2.x()) / s;
+    bitangents[indices[i]] += bitan;
+    bitangents[indices[i + 1U]] += bitan;
+    bitangents[indices[i + 2U]] += bitan;
+  }
+
+  // Write the tangents to the vertices vector.
+  for (auto i = 0U; i != vertices.size(); ++i) {
+    const auto& t = tangents[i];        // tangent.
+    const auto& b = bitangents[i];      // bitangent.
+    const auto& n = vertices[i].normal; // normal.
+    if (math::approxZero(t)) {
+      // Not possible to calculate a tangent, vertex is not used in any triangle with non-zero
+      // positional area and texcoord area.
+      vertices[i].tangent = {.1f, 0.f, 0.f, 1.f};
+      continue;
+    }
+
+    // Ortho-normalize the tangent in case the texcoords are skewed.
+    const auto tan = (t - project(t, n)).getNorm();
+
+    vertices[i].tangent.x() = tan.x();
+    vertices[i].tangent.y() = tan.y();
+    vertices[i].tangent.z() = tan.z();
+
+    // Calculate the 'handedness', aka if the bi-tangent needs to be flipped.
+    vertices[i].tangent.w() = (dot(cross(n, t), b) < 0.f) ? 1.f : -1.f;
+  }
+
+  std::free(buffer);
+}
+
+} // namespace tria::asset::internal

--- a/src/tria/asset/internal/mesh_utils.hpp
+++ b/src/tria/asset/internal/mesh_utils.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "tria/asset/mesh.hpp"
+
+namespace tria::asset::internal {
+
+/* Calculate smooth tangents based on the vertex normals and texcoords.
+ * Results are written to the 'tangent' property of the vertices vector, 'w' coordinate contains the
+ * 'handedness' of the axis system, either '1' or '-1'.
+ */
+auto computeTangents(
+    math::PodVector<Vertex>& vertices, const math::PodVector<IndexType>& indices) noexcept -> void;
+
+} // namespace tria::asset::internal

--- a/src/tria/gfx_vulkan/internal/device.cpp
+++ b/src/tria/gfx_vulkan/internal/device.cpp
@@ -72,15 +72,14 @@ constexpr std::array<const char*, 1> g_requiredDeviceExtensions = {
 
   const auto availableFormats = getVkSurfaceFormats(vkPhysicalDevice, vkSurface);
 
-  // Prefer SRGB.
+  // Prefer srgb, so the gpu can itself perform the linear to srgb conversion.
   for (const auto& format : availableFormats) {
-    if (format.format == VK_FORMAT_B8G8R8A8_SRGB &&
-        format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+    if (format.format == VK_FORMAT_B8G8R8A8_SRGB) {
       return format;
     }
   }
   // If thats not availble then pick whatever is available.
-  // Note: In the future we could consider add some scoring algorithm here.
+  // Note: In the future we could consider adding some scoring algorithm here.
   return availableFormats.empty() ? std::nullopt : std::optional(*availableFormats.begin());
 }
 

--- a/src/tria/gfx_vulkan/internal/mesh.cpp
+++ b/src/tria/gfx_vulkan/internal/mesh.cpp
@@ -45,6 +45,7 @@ auto Mesh::prepareResources(Transferer* transferer) const -> void {
       // TODO(bastian): We could pack the normal data using 8 bit per channel.
       devItr->nrm       = itr->normal;
       devItr->texcoordY = itr->texcoord.y();
+      devItr->tan       = itr->tangent;
     }
     transferer->queueTransfer(deviceVertexData.begin(), m_vertexBuffer, 0U, m_vertexDataSize);
 

--- a/src/tria/gfx_vulkan/internal/mesh.hpp
+++ b/src/tria/gfx_vulkan/internal/mesh.hpp
@@ -15,6 +15,7 @@ struct alignas(16) DeviceVertex final {
   float texcoordX;
   math::Vec3f nrm;
   float texcoordY;
+  math::Vec4f tan; // 'w' indicates the handedness, either '1' or '-1'.
 };
 
 /* Mesh resource.

--- a/src/tria/gfx_vulkan/internal/texture.cpp
+++ b/src/tria/gfx_vulkan/internal/texture.cpp
@@ -11,7 +11,7 @@ Texture::Texture(log::Logger* logger, Device* device, const asset::Texture* asse
   assert(device);
   assert(m_asset);
 
-  const auto vkFormat = VK_FORMAT_R8G8B8A8_SRGB;
+  const auto vkFormat = VK_FORMAT_R8G8B8A8_UNORM;
   assert(getVkFormatSize(vkFormat) == sizeof(asset::Pixel));
   assert(getVkFormatChannelCount(vkFormat) == 4U);
   m_image = Image{device,

--- a/tests/tria/asset/mesh_obj_test.cpp
+++ b/tests/tria/asset/mesh_obj_test.cpp
@@ -66,9 +66,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {}},
-                         {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}}}));
     });
   }
 
@@ -89,9 +90,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {1.f, 0.f, 0.f}, {}},
-                         {{2.0, 5.0, 8.0}, {0.f, 1.f, 0.f}, {}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {1.f, 0.f, 0.f}, {1., 0., 0., 1.}, {}},
+               {{2.0, 5.0, 8.0}, {0.f, 1.f, 0.f}, {1., 0., 0., 1.}, {}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}}}));
     });
   }
 
@@ -115,9 +117,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {1.f, 0.f, 0.f}, {0.1, 0.5}},
-                         {{2.0, 5.0, 8.0}, {0.f, 1.f, 0.f}, {0.3, 0.5}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {0.5, 0.5}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {1.f, 0.f, 0.f}, {1., 0., 0., 1.}, {0.1, 0.5}},
+               {{2.0, 5.0, 8.0}, {0.f, 1.f, 0.f}, {1., 0., 0., 1.}, {0.3, 0.5}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.5, 0.5}}}));
     });
   }
 
@@ -138,9 +141,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {0.1, 0.5}},
-                         {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {0.3, 0.5}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {0.5, 0.5}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.1, 0.5}},
+               {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.3, 0.5}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.5, 0.5}}}));
     });
   }
 
@@ -159,9 +163,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {0.5, 0.5}},
-                         {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {0.5, 0.5}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {0.5, 0.5}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.5, 0.5}},
+               {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.5, 0.5}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {0.5, 0.5}}}));
     });
   }
 
@@ -197,10 +202,11 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto indices  = std::vector<IndexType>(mesh->getIndexBegin(), mesh->getIndexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{-0.5, -0.5, 0.0}, {0.f, 0.f, 1.f}, {}},
-                         {{+0.5, -0.5, 0.0}, {0.f, 0.f, 1.f}, {}},
-                         {{-0.5, +0.5, 0.0}, {0.f, 0.f, 1.f}, {}},
-                         {{+0.5, +0.5, 0.0}, {0.f, 0.f, 1.f}, {}}}));
+          VertexMatcher(
+              {{{-0.5, -0.5, 0.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{+0.5, -0.5, 0.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{-0.5, +0.5, 0.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{+0.5, +0.5, 0.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}}}));
       CHECK(indices == std::vector<IndexType>{0, 1, 2, 0, 2, 3});
     });
   }
@@ -223,12 +229,13 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 2.0, 3.0}, {0.f, 0.f, 1.f}, {}},
-                         {{4.0, 5.0, 6.0}, {0.f, 0.f, 1.f}, {}},
-                         {{7.0, 8.0, 9.0}, {0.f, 0.f, 1.f}, {}},
-                         {{16.0, 17.0, 18.0}, {0.f, 0.f, 1.f}, {}},
-                         {{13.0, 14.0, 15.0}, {0.f, 0.f, 1.f}, {}},
-                         {{10.0, 11.0, 12.0}, {0.f, 0.f, 1.f}, {}}}));
+          VertexMatcher(
+              {{{1.0, 2.0, 3.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{4.0, 5.0, 6.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{7.0, 8.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{16.0, 17.0, 18.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{13.0, 14.0, 15.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{10.0, 11.0, 12.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}}}));
     });
   }
 
@@ -251,9 +258,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {}},
-                         {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}}}));
     });
   }
 
@@ -271,9 +279,10 @@ TEST_CASE("[asset] - Mesh Wavefront Obj", "[asset]") {
       auto vertices = std::vector<Vertex>(mesh->getVertexBegin(), mesh->getVertexEnd());
       CHECK_THAT(
           vertices,
-          VertexMatcher({{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {}},
-                         {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {}},
-                         {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {}}}));
+          VertexMatcher(
+              {{{1.0, 4.0, 7.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{2.0, 5.0, 8.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}},
+               {{3.0, 6.0, 9.0}, {0.f, 0.f, 1.f}, {1., 0., 0., 1.}, {}}}));
     });
   }
 


### PR DESCRIPTION
Calculate smooth vertex tangents based on texture coordinates when importing a mesh.

![img](https://user-images.githubusercontent.com/14230060/92307059-59dfd780-ef9c-11ea-8225-10cbc84b7284.png)
Blue are normals and red are the tangents, binormals are formed implicitly by crossing the normal and the tangent.

Mesh with per vertex normals:
![mesh_normals](https://user-images.githubusercontent.com/14230060/92307107-a75c4480-ef9c-11ea-9e2e-f4363e0aab42.png)

Same mesh but with a tangent space normal map applied:
![img_normalmapped](https://user-images.githubusercontent.com/14230060/92307133-c35fe600-ef9c-11ea-8935-0a9ec7e6f5f7.png)

Basic directional lighting (left with per vertex normals and right with a normal map):
![lighting](https://user-images.githubusercontent.com/14230060/92307152-e094b480-ef9c-11ea-92a0-67e27471a0dd.png)

